### PR TITLE
Port to tvOS

### DIFF
--- a/Sources/Models/ConfigurationMDB.swift
+++ b/Sources/Models/ConfigurationMDB.swift
@@ -23,12 +23,12 @@ public struct ConfigurationMDB {
     let images = results["images"]
     base_url = images["base_url"].string
     secure_base_url = images["secure_base_url"].string
-    backdrop_sizes = images["backdrop_sizes"].arrayObject as! [String]
-    logo_sizes = images["logo_sizes"].arrayObject as! [String]
-    poster_sizes = images["poster_sizes"].arrayObject as! [String]
-    profile_sizes = images["profile_sizes"].arrayObject as! [String]
-    still_sizes = images["still_sizes"].arrayObject as! [String]
-    change_keys = results["change_keys"].arrayObject as! [String]
+    backdrop_sizes = images["backdrop_sizes"].arrayObject as? [String]
+    logo_sizes = images["logo_sizes"].arrayObject as? [String]
+    poster_sizes = images["poster_sizes"].arrayObject as? [String]
+    profile_sizes = images["profile_sizes"].arrayObject as? [String]
+    still_sizes = images["still_sizes"].arrayObject as? [String]
+    change_keys = results["change_keys"].arrayObject as? [String]
   }
   
   ///This method currently holds the data relevant to building image URLs as well as the change key map.To build an image URL, you will need 3 pieces of data. The base_url, size and file path; . Simply combine them all and you will have a fully qualified URL. Here’s an example URL: http://image.tmdb.org/t/p/w500/8uO0gUM8aNqYLs1OsTBQiXu0fEv.jpg

--- a/Sources/Models/TVDetailedMDB.swift
+++ b/Sources/Models/TVDetailedMDB.swift
@@ -62,7 +62,7 @@ open class TVDetailedMDB: TVMDB{
       createdBy = tv_created_By.init(id: results["created_by"][0]["id"].int, name: results["created_by"][0]["name"].string, profile_path: results["created_by"][0]["profile_path"].string)
     }
     
-    episode_run_time = results["episode_run_time"].arrayObject as! [Int]
+    episode_run_time = results["episode_run_time"].arrayObject as? [Int]
     //        genres = KeywordsMDB.init(results: results["genres"])
     homepage = results["homepage"].string
     in_production = results["in_production"].bool

--- a/TMDBSwift.xcodeproj/project.pbxproj
+++ b/TMDBSwift.xcodeproj/project.pbxproj
@@ -135,6 +135,70 @@
 		6F62A11520CB9A20000744A9 /* TMDBSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F62A11020CB9A18000744A9 /* TMDBSwiftTests.swift */; };
 		6F62A11620CB9A20000744A9 /* FindMDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F62A11120CB9A18000744A9 /* FindMDBTests.swift */; };
 		6F62A11720CB9A20000744A9 /* MovieMDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F62A10F20CB9A18000744A9 /* MovieMDBTests.swift */; };
+		D1D3B4D2212980C2002B3486 /* TMDBSwiftTvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D1D3B4C9212980C2002B3486 /* TMDBSwiftTvOS.framework */; };
+		D1D3B4D9212980C2002B3486 /* TMDBSwiftTvOS.h in Headers */ = {isa = PBXBuildFile; fileRef = D1D3B4CB212980C2002B3486 /* TMDBSwiftTvOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D1D3B4E021298148002B3486 /* ArrayObjectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF143611CF0A3FB009C620D /* ArrayObjectProtocol.swift */; };
+		D1D3B4E121298148002B3486 /* SwiftyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E66E1841D8F8B490044A901 /* SwiftyJSON.swift */; };
+		D1D3B4E22129814D002B3486 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A7ACE61FC4857900FAE133 /* Config.swift */; };
+		D1D3B4E32129814D002B3486 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B30B1CB732C900B49F4E /* Client.swift */; };
+		D1D3B4E42129814D002B3486 /* Clent_Discover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B30A1CB732C900B49F4E /* Clent_Discover.swift */; };
+		D1D3B4E52129814D002B3486 /* Client_Certifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B30C1CB732C900B49F4E /* Client_Certifications.swift */; };
+		D1D3B4E62129814D002B3486 /* Client_Changes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B30D1CB732C900B49F4E /* Client_Changes.swift */; };
+		D1D3B4E72129814D002B3486 /* Client_Collections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B30E1CB732C900B49F4E /* Client_Collections.swift */; };
+		D1D3B4E82129814D002B3486 /* Client_Companies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B30F1CB732C900B49F4E /* Client_Companies.swift */; };
+		D1D3B4E92129814D002B3486 /* Client_Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3101CB732C900B49F4E /* Client_Configuration.swift */; };
+		D1D3B4EA2129814D002B3486 /* Client_Credits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3111CB732C900B49F4E /* Client_Credits.swift */; };
+		D1D3B4EB2129814D002B3486 /* Client_Find.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3121CB732C900B49F4E /* Client_Find.swift */; };
+		D1D3B4EC2129814D002B3486 /* Client_Genres.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3131CB732C900B49F4E /* Client_Genres.swift */; };
+		D1D3B4ED2129814D002B3486 /* Client_Keywords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3141CB732C900B49F4E /* Client_Keywords.swift */; };
+		D1D3B4EE2129814D002B3486 /* Client_Lists.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3151CB732C900B49F4E /* Client_Lists.swift */; };
+		D1D3B4EF2129814D002B3486 /* Client_Movies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3161CB732C900B49F4E /* Client_Movies.swift */; };
+		D1D3B4F02129814D002B3486 /* Client_Networks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3171CB732C900B49F4E /* Client_Networks.swift */; };
+		D1D3B4F12129814D002B3486 /* Client_People.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3181CB732C900B49F4E /* Client_People.swift */; };
+		D1D3B4F22129814D002B3486 /* Client_Review.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3191CB732C900B49F4E /* Client_Review.swift */; };
+		D1D3B4F32129814D002B3486 /* Client_TV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B31A1CB732C900B49F4E /* Client_TV.swift */; };
+		D1D3B4F42129814D002B3486 /* Client_TVSeasonsEpisodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B31B1CB732C900B49F4E /* Client_TVSeasonsEpisodes.swift */; };
+		D1D3B4F52129814D002B3486 /* Client_Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5774C0D61CF751B40045F0CE /* Client_Search.swift */; };
+		D1D3B4F62129815B002B3486 /* Alternative_TitlesMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B31D1CB732C900B49F4E /* Alternative_TitlesMDB.swift */; };
+		D1D3B4F72129815B002B3486 /* CastCrewMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B31E1CB732C900B49F4E /* CastCrewMDB.swift */; };
+		D1D3B4F82129815B002B3486 /* CertificationMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E56F3241D0781A500CAED06 /* CertificationMDB.swift */; };
+		D1D3B4F92129815B002B3486 /* ChangesMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B31F1CB732C900B49F4E /* ChangesMDB.swift */; };
+		D1D3B4FA2129815B002B3486 /* CollectionsMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3201CB732C900B49F4E /* CollectionsMDB.swift */; };
+		D1D3B4FB2129815B002B3486 /* CompaniesMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3211CB732C900B49F4E /* CompaniesMDB.swift */; };
+		D1D3B4FC2129815B002B3486 /* ConfigurationMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3221CB732C900B49F4E /* ConfigurationMDB.swift */; };
+		D1D3B4FD2129815B002B3486 /* CreditsMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3231CB732C900B49F4E /* CreditsMDB.swift */; };
+		D1D3B4FE2129815B002B3486 /* Discover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3251CB732C900B49F4E /* Discover.swift */; };
+		D1D3B4FF2129815B002B3486 /* DiscoverMovie.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3261CB732C900B49F4E /* DiscoverMovie.swift */; };
+		D1D3B5002129815B002B3486 /* DiscoverTV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3271CB732C900B49F4E /* DiscoverTV.swift */; };
+		D1D3B5012129815B002B3486 /* ExternalIdsMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3281CB732C900B49F4E /* ExternalIdsMDB.swift */; };
+		D1D3B5022129815B002B3486 /* FindMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3291CB732C900B49F4E /* FindMDB.swift */; };
+		D1D3B5032129815B002B3486 /* GenresMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B32A1CB732C900B49F4E /* GenresMDB.swift */; };
+		D1D3B5042129815B002B3486 /* ImagesMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B32B1CB732C900B49F4E /* ImagesMDB.swift */; };
+		D1D3B5052129815B002B3486 /* KeywordsMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B32C1CB732C900B49F4E /* KeywordsMDB.swift */; };
+		D1D3B5062129815B002B3486 /* ListsMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B32D1CB732C900B49F4E /* ListsMDB.swift */; };
+		D1D3B50721298162002B3486 /* MovieCreditsMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B32E1CB732C900B49F4E /* MovieCreditsMDB.swift */; };
+		D1D3B50821298162002B3486 /* MovieDetailedMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B32F1CB732C900B49F4E /* MovieDetailedMDB.swift */; };
+		D1D3B50921298162002B3486 /* MovieListMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3301CB732C900B49F4E /* MovieListMDB.swift */; };
+		D1D3B50A21298162002B3486 /* MovieMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3311CB732C900B49F4E /* MovieMDB.swift */; };
+		D1D3B50B21298162002B3486 /* MovieMDBModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3321CB732C900B49F4E /* MovieMDBModel.swift */; };
+		D1D3B50C21298162002B3486 /* MovieReleaseDatesMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3331CB732C900B49F4E /* MovieReleaseDatesMDB.swift */; };
+		D1D3B50D21298162002B3486 /* MovieReviewMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3341CB732C900B49F4E /* MovieReviewMDB.swift */; };
+		D1D3B50E21298162002B3486 /* NetworksMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3351CB732C900B49F4E /* NetworksMDB.swift */; };
+		D1D3B50F21298162002B3486 /* PageResultsMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3361CB732C900B49F4E /* PageResultsMDB.swift */; };
+		D1D3B51021298162002B3486 /* PersonMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3371CB732C900B49F4E /* PersonMDB.swift */; };
+		D1D3B51121298162002B3486 /* ReviewsMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3391CB732C900B49F4E /* ReviewsMDB.swift */; };
+		D1D3B51221298162002B3486 /* TranslationsMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B33A1CB732C900B49F4E /* TranslationsMDB.swift */; };
+		D1D3B5132129816A002B3486 /* TVMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B33E1CB732C900B49F4E /* TVMDB.swift */; };
+		D1D3B5142129816A002B3486 /* TVMDBModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B33F1CB732C900B49F4E /* TVMDBModel.swift */; };
+		D1D3B5152129816A002B3486 /* TVCreditsMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B33B1CB732C900B49F4E /* TVCreditsMDB.swift */; };
+		D1D3B5162129816A002B3486 /* TVDetailedMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B33C1CB732C900B49F4E /* TVDetailedMDB.swift */; };
+		D1D3B5172129816A002B3486 /* TVEpisodesMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B33D1CB732C900B49F4E /* TVEpisodesMDB.swift */; };
+		D1D3B5182129816A002B3486 /* TVSeasonsMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3401CB732C900B49F4E /* TVSeasonsMDB.swift */; };
+		D1D3B5192129816A002B3486 /* VideosMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3411CB732C900B49F4E /* VideosMDB.swift */; };
+		D1D3B51A2129816A002B3486 /* SearchMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5774C0D81CF757120045F0CE /* SearchMDB.swift */; };
+		D1D3B51E212981C9002B3486 /* TMDBSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D3B51B212981BB002B3486 /* TMDBSwiftTests.swift */; };
+		D1D3B51F212981C9002B3486 /* FindMDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D3B51D212981BB002B3486 /* FindMDBTests.swift */; };
+		D1D3B520212981C9002B3486 /* MovieMDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D3B51C212981BB002B3486 /* MovieMDBTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -151,6 +215,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 6F62A0B320CB935F000744A9;
 			remoteInfo = TMDBSwiftMac;
+		};
+		D1D3B4D3212980C2002B3486 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5EF1B2621CB72DBF00B49F4E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D1D3B4C8212980C2002B3486;
+			remoteInfo = TMDBSwiftTvOS;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -232,6 +303,14 @@
 		6F62A10F20CB9A18000744A9 /* MovieMDBTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieMDBTests.swift; sourceTree = "<group>"; };
 		6F62A11020CB9A18000744A9 /* TMDBSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TMDBSwiftTests.swift; sourceTree = "<group>"; };
 		6F62A11120CB9A18000744A9 /* FindMDBTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindMDBTests.swift; sourceTree = "<group>"; };
+		D1D3B4C9212980C2002B3486 /* TMDBSwiftTvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TMDBSwiftTvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D1D3B4CB212980C2002B3486 /* TMDBSwiftTvOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TMDBSwiftTvOS.h; sourceTree = "<group>"; };
+		D1D3B4CC212980C2002B3486 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D1D3B4D1212980C2002B3486 /* TMDBSwiftTvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TMDBSwiftTvOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D1D3B4D8212980C2002B3486 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D1D3B51B212981BB002B3486 /* TMDBSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TMDBSwiftTests.swift; sourceTree = "<group>"; };
+		D1D3B51C212981BB002B3486 /* MovieMDBTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieMDBTests.swift; sourceTree = "<group>"; };
+		D1D3B51D212981BB002B3486 /* FindMDBTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindMDBTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -262,6 +341,21 @@
 			buildActionMask = 2147483647;
 			files = (
 				6F62A0BD20CB9360000744A9 /* TMDBSwiftMac.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D1D3B4C6212980C2002B3486 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D1D3B4CE212980C2002B3486 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D1D3B4D2212980C2002B3486 /* TMDBSwiftTvOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -327,6 +421,8 @@
 				5EF1B2791CB72DC000B49F4E /* TMDBSwiftTests */,
 				6F62A0B520CB935F000744A9 /* TMDBSwiftMac */,
 				6F62A0C020CB9360000744A9 /* TMDBSwiftMacTests */,
+				D1D3B4CA212980C2002B3486 /* TMDBSwiftTvOS */,
+				D1D3B4D5212980C2002B3486 /* TMDBSwiftTvOSTests */,
 				5EF1B26C1CB72DBF00B49F4E /* Products */,
 				185875F8E34AE1EB1192AE53 /* Frameworks */,
 			);
@@ -341,6 +437,8 @@
 				5EF1B2751CB72DC000B49F4E /* TMDBSwiftTests.xctest */,
 				6F62A0B420CB935F000744A9 /* TMDBSwiftMac.framework */,
 				6F62A0BC20CB935F000744A9 /* TMDBSwiftMacTests.xctest */,
+				D1D3B4C9212980C2002B3486 /* TMDBSwiftTvOS.framework */,
+				D1D3B4D1212980C2002B3486 /* TMDBSwiftTvOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -457,6 +555,26 @@
 			path = TMDBSwiftMacTests;
 			sourceTree = "<group>";
 		};
+		D1D3B4CA212980C2002B3486 /* TMDBSwiftTvOS */ = {
+			isa = PBXGroup;
+			children = (
+				D1D3B4CB212980C2002B3486 /* TMDBSwiftTvOS.h */,
+				D1D3B4CC212980C2002B3486 /* Info.plist */,
+			);
+			path = TMDBSwiftTvOS;
+			sourceTree = "<group>";
+		};
+		D1D3B4D5212980C2002B3486 /* TMDBSwiftTvOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				D1D3B51B212981BB002B3486 /* TMDBSwiftTests.swift */,
+				D1D3B51D212981BB002B3486 /* FindMDBTests.swift */,
+				D1D3B51C212981BB002B3486 /* MovieMDBTests.swift */,
+				D1D3B4D8212980C2002B3486 /* Info.plist */,
+			);
+			path = TMDBSwiftTvOSTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -473,6 +591,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				6F62A0C420CB9360000744A9 /* TMDBSwiftMac.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D1D3B4C4212980C2002B3486 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D1D3B4D9212980C2002B3486 /* TMDBSwiftTvOS.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -551,14 +677,50 @@
 			productReference = 6F62A0BC20CB935F000744A9 /* TMDBSwiftMacTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		D1D3B4C8212980C2002B3486 /* TMDBSwiftTvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D1D3B4DA212980C2002B3486 /* Build configuration list for PBXNativeTarget "TMDBSwiftTvOS" */;
+			buildPhases = (
+				D1D3B4C4212980C2002B3486 /* Headers */,
+				D1D3B4C5212980C2002B3486 /* Sources */,
+				D1D3B4C6212980C2002B3486 /* Frameworks */,
+				D1D3B4C7212980C2002B3486 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TMDBSwiftTvOS;
+			productName = TMDBSwiftTvOS;
+			productReference = D1D3B4C9212980C2002B3486 /* TMDBSwiftTvOS.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		D1D3B4D0212980C2002B3486 /* TMDBSwiftTvOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D1D3B4DD212980C2002B3486 /* Build configuration list for PBXNativeTarget "TMDBSwiftTvOSTests" */;
+			buildPhases = (
+				D1D3B4CD212980C2002B3486 /* Sources */,
+				D1D3B4CE212980C2002B3486 /* Frameworks */,
+				D1D3B4CF212980C2002B3486 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D1D3B4D4212980C2002B3486 /* PBXTargetDependency */,
+			);
+			name = TMDBSwiftTvOSTests;
+			productName = TMDBSwiftTvOSTests;
+			productReference = D1D3B4D1212980C2002B3486 /* TMDBSwiftTvOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		5EF1B2621CB72DBF00B49F4E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0940;
-				LastUpgradeCheck = 0900;
+				LastSwiftUpdateCheck = 1000;
+				LastUpgradeCheck = 1000;
 				ORGANIZATIONNAME = George;
 				TargetAttributes = {
 					5EF1B26A1CB72DBF00B49F4E = {
@@ -567,16 +729,30 @@
 					};
 					5EF1B2741CB72DC000B49F4E = {
 						CreatedOnToolsVersion = 7.3;
-						DevelopmentTeam = 2JJGDVS5KS;
+						DevelopmentTeam = 3F89ZY3P47;
 						LastSwiftMigration = 0900;
+						ProvisioningStyle = Automatic;
 					};
 					6F62A0B320CB935F000744A9 = {
 						CreatedOnToolsVersion = 9.4;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Manual;
 					};
 					6F62A0BB20CB935F000744A9 = {
 						CreatedOnToolsVersion = 9.4;
-						DevelopmentTeam = U3HG6UAV5D;
+						DevelopmentTeam = 3F89ZY3P47;
+						LastSwiftMigration = 1000;
+						ProvisioningStyle = Manual;
+					};
+					D1D3B4C8212980C2002B3486 = {
+						CreatedOnToolsVersion = 10.0;
+						LastSwiftMigration = 1000;
+						ProvisioningStyle = Automatic;
+					};
+					D1D3B4D0212980C2002B3486 = {
+						CreatedOnToolsVersion = 10.0;
+						DevelopmentTeam = 3F89ZY3P47;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -598,6 +774,8 @@
 				5EF1B2741CB72DC000B49F4E /* TMDBSwiftTests */,
 				6F62A0B320CB935F000744A9 /* TMDBSwiftMac */,
 				6F62A0BB20CB935F000744A9 /* TMDBSwiftMacTests */,
+				D1D3B4C8212980C2002B3486 /* TMDBSwiftTvOS */,
+				D1D3B4D0212980C2002B3486 /* TMDBSwiftTvOSTests */,
 			);
 		};
 /* End PBXProject section */
@@ -625,6 +803,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		6F62A0BA20CB935F000744A9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D1D3B4C7212980C2002B3486 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D1D3B4CF212980C2002B3486 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -786,6 +978,82 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D1D3B4C5212980C2002B3486 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D1D3B4F82129815B002B3486 /* CertificationMDB.swift in Sources */,
+				D1D3B4E72129814D002B3486 /* Client_Collections.swift in Sources */,
+				D1D3B4E021298148002B3486 /* ArrayObjectProtocol.swift in Sources */,
+				D1D3B4FE2129815B002B3486 /* Discover.swift in Sources */,
+				D1D3B4ED2129814D002B3486 /* Client_Keywords.swift in Sources */,
+				D1D3B4E52129814D002B3486 /* Client_Certifications.swift in Sources */,
+				D1D3B5152129816A002B3486 /* TVCreditsMDB.swift in Sources */,
+				D1D3B5172129816A002B3486 /* TVEpisodesMDB.swift in Sources */,
+				D1D3B50A21298162002B3486 /* MovieMDB.swift in Sources */,
+				D1D3B4F92129815B002B3486 /* ChangesMDB.swift in Sources */,
+				D1D3B4E92129814D002B3486 /* Client_Configuration.swift in Sources */,
+				D1D3B4E121298148002B3486 /* SwiftyJSON.swift in Sources */,
+				D1D3B4F62129815B002B3486 /* Alternative_TitlesMDB.swift in Sources */,
+				D1D3B50921298162002B3486 /* MovieListMDB.swift in Sources */,
+				D1D3B50D21298162002B3486 /* MovieReviewMDB.swift in Sources */,
+				D1D3B4F22129814D002B3486 /* Client_Review.swift in Sources */,
+				D1D3B4E32129814D002B3486 /* Client.swift in Sources */,
+				D1D3B4FB2129815B002B3486 /* CompaniesMDB.swift in Sources */,
+				D1D3B4FF2129815B002B3486 /* DiscoverMovie.swift in Sources */,
+				D1D3B4E22129814D002B3486 /* Config.swift in Sources */,
+				D1D3B4EC2129814D002B3486 /* Client_Genres.swift in Sources */,
+				D1D3B4F72129815B002B3486 /* CastCrewMDB.swift in Sources */,
+				D1D3B50721298162002B3486 /* MovieCreditsMDB.swift in Sources */,
+				D1D3B4F42129814D002B3486 /* Client_TVSeasonsEpisodes.swift in Sources */,
+				D1D3B4EB2129814D002B3486 /* Client_Find.swift in Sources */,
+				D1D3B51021298162002B3486 /* PersonMDB.swift in Sources */,
+				D1D3B5002129815B002B3486 /* DiscoverTV.swift in Sources */,
+				D1D3B4E82129814D002B3486 /* Client_Companies.swift in Sources */,
+				D1D3B4FC2129815B002B3486 /* ConfigurationMDB.swift in Sources */,
+				D1D3B50E21298162002B3486 /* NetworksMDB.swift in Sources */,
+				D1D3B50C21298162002B3486 /* MovieReleaseDatesMDB.swift in Sources */,
+				D1D3B4F02129814D002B3486 /* Client_Networks.swift in Sources */,
+				D1D3B4EE2129814D002B3486 /* Client_Lists.swift in Sources */,
+				D1D3B4FA2129815B002B3486 /* CollectionsMDB.swift in Sources */,
+				D1D3B5032129815B002B3486 /* GenresMDB.swift in Sources */,
+				D1D3B5042129815B002B3486 /* ImagesMDB.swift in Sources */,
+				D1D3B50F21298162002B3486 /* PageResultsMDB.swift in Sources */,
+				D1D3B5132129816A002B3486 /* TVMDB.swift in Sources */,
+				D1D3B51A2129816A002B3486 /* SearchMDB.swift in Sources */,
+				D1D3B4E62129814D002B3486 /* Client_Changes.swift in Sources */,
+				D1D3B5182129816A002B3486 /* TVSeasonsMDB.swift in Sources */,
+				D1D3B4F52129814D002B3486 /* Client_Search.swift in Sources */,
+				D1D3B51221298162002B3486 /* TranslationsMDB.swift in Sources */,
+				D1D3B5142129816A002B3486 /* TVMDBModel.swift in Sources */,
+				D1D3B5052129815B002B3486 /* KeywordsMDB.swift in Sources */,
+				D1D3B5162129816A002B3486 /* TVDetailedMDB.swift in Sources */,
+				D1D3B4EA2129814D002B3486 /* Client_Credits.swift in Sources */,
+				D1D3B51121298162002B3486 /* ReviewsMDB.swift in Sources */,
+				D1D3B5192129816A002B3486 /* VideosMDB.swift in Sources */,
+				D1D3B5022129815B002B3486 /* FindMDB.swift in Sources */,
+				D1D3B4F12129814D002B3486 /* Client_People.swift in Sources */,
+				D1D3B5012129815B002B3486 /* ExternalIdsMDB.swift in Sources */,
+				D1D3B4E42129814D002B3486 /* Clent_Discover.swift in Sources */,
+				D1D3B50B21298162002B3486 /* MovieMDBModel.swift in Sources */,
+				D1D3B5062129815B002B3486 /* ListsMDB.swift in Sources */,
+				D1D3B50821298162002B3486 /* MovieDetailedMDB.swift in Sources */,
+				D1D3B4F32129814D002B3486 /* Client_TV.swift in Sources */,
+				D1D3B4FD2129815B002B3486 /* CreditsMDB.swift in Sources */,
+				D1D3B4EF2129814D002B3486 /* Client_Movies.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D1D3B4CD212980C2002B3486 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D1D3B520212981C9002B3486 /* MovieMDBTests.swift in Sources */,
+				D1D3B51F212981C9002B3486 /* FindMDBTests.swift in Sources */,
+				D1D3B51E212981C9002B3486 /* TMDBSwiftTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -798,6 +1066,11 @@
 			isa = PBXTargetDependency;
 			target = 6F62A0B320CB935F000744A9 /* TMDBSwiftMac */;
 			targetProxy = 6F62A0BE20CB9360000744A9 /* PBXContainerItemProxy */;
+		};
+		D1D3B4D4212980C2002B3486 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D1D3B4C8212980C2002B3486 /* TMDBSwiftTvOS */;
+			targetProxy = D1D3B4D3212980C2002B3486 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -815,12 +1088,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -872,12 +1147,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -929,7 +1206,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -951,7 +1228,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -961,13 +1238,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = 2JJGDVS5KS;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 3F89ZY3P47;
 				INFOPLIST_FILE = TMDBSwiftTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = GeorgeKye.TMDBSwiftTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
@@ -976,12 +1256,15 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = 2JJGDVS5KS;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 3F89ZY3P47;
 				INFOPLIST_FILE = TMDBSwiftTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = GeorgeKye.TMDBSwiftTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
@@ -996,7 +1279,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -1030,7 +1313,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -1065,15 +1348,16 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "Mac Developer";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = U3HG6UAV5D;
+				DEVELOPMENT_TEAM = 3F89ZY3P47;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = TMDBSwiftMacTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.the-skylab.TMDBSwiftMacTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 4.0;
@@ -1092,17 +1376,128 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "Mac Developer";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = U3HG6UAV5D;
+				DEVELOPMENT_TEAM = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = TMDBSwiftMacTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.the-skylab.TMDBSwiftMacTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		D1D3B4DB212980C2002B3486 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = TMDBSwiftTvOS/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = GeorgeKye.TMDBSwift;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 10.2;
+			};
+			name = Debug;
+		};
+		D1D3B4DC212980C2002B3486 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = TMDBSwiftTvOS/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = GeorgeKye.TMDBSwift;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 10.2;
+			};
+			name = Release;
+		};
+		D1D3B4DE212980C2002B3486 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 3F89ZY3P47;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = TMDBSwiftTvOSTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = eu.notsobright.TMDBSwiftTvOSTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
+			};
+			name = Debug;
+		};
+		D1D3B4DF212980C2002B3486 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 3F89ZY3P47;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = TMDBSwiftTvOSTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = eu.notsobright.TMDBSwiftTvOSTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Release;
 		};
@@ -1150,6 +1545,24 @@
 			buildConfigurations = (
 				6F62A0C720CB9360000744A9 /* Debug */,
 				6F62A0C820CB9360000744A9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D1D3B4DA212980C2002B3486 /* Build configuration list for PBXNativeTarget "TMDBSwiftTvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D1D3B4DB212980C2002B3486 /* Debug */,
+				D1D3B4DC212980C2002B3486 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D1D3B4DD212980C2002B3486 /* Build configuration list for PBXNativeTarget "TMDBSwiftTvOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D1D3B4DE212980C2002B3486 /* Debug */,
+				D1D3B4DF212980C2002B3486 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/TMDBSwift.xcodeproj/project.pbxproj
+++ b/TMDBSwift.xcodeproj/project.pbxproj
@@ -134,7 +134,6 @@
 		6F62A10E20CB9471000744A9 /* SearchMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5774C0D81CF757120045F0CE /* SearchMDB.swift */; };
 		6F62A11520CB9A20000744A9 /* TMDBSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F62A11020CB9A18000744A9 /* TMDBSwiftTests.swift */; };
 		6F62A11620CB9A20000744A9 /* FindMDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F62A11120CB9A18000744A9 /* FindMDBTests.swift */; };
-		6F62A11720CB9A20000744A9 /* MovieMDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F62A10F20CB9A18000744A9 /* MovieMDBTests.swift */; };
 		D1D3B4D2212980C2002B3486 /* TMDBSwiftTvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D1D3B4C9212980C2002B3486 /* TMDBSwiftTvOS.framework */; };
 		D1D3B4D9212980C2002B3486 /* TMDBSwiftTvOS.h in Headers */ = {isa = PBXBuildFile; fileRef = D1D3B4CB212980C2002B3486 /* TMDBSwiftTvOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D1D3B4E021298148002B3486 /* ArrayObjectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF143611CF0A3FB009C620D /* ArrayObjectProtocol.swift */; };
@@ -199,6 +198,7 @@
 		D1D3B51E212981C9002B3486 /* TMDBSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D3B51B212981BB002B3486 /* TMDBSwiftTests.swift */; };
 		D1D3B51F212981C9002B3486 /* FindMDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D3B51D212981BB002B3486 /* FindMDBTests.swift */; };
 		D1D3B520212981C9002B3486 /* MovieMDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D3B51C212981BB002B3486 /* MovieMDBTests.swift */; };
+		D1D3B5222129ED24002B3486 /* MovieMDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D3B5212129ED24002B3486 /* MovieMDBTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -300,7 +300,7 @@
 		6F62A0B720CB935F000744A9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6F62A0BC20CB935F000744A9 /* TMDBSwiftMacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TMDBSwiftMacTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F62A0C320CB9360000744A9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		6F62A10F20CB9A18000744A9 /* MovieMDBTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieMDBTests.swift; sourceTree = "<group>"; };
+		6F62A10F20CB9A18000744A9 /* MovieMDBTests-old.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MovieMDBTests-old.swift"; sourceTree = "<group>"; };
 		6F62A11020CB9A18000744A9 /* TMDBSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TMDBSwiftTests.swift; sourceTree = "<group>"; };
 		6F62A11120CB9A18000744A9 /* FindMDBTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindMDBTests.swift; sourceTree = "<group>"; };
 		D1D3B4C9212980C2002B3486 /* TMDBSwiftTvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TMDBSwiftTvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -311,6 +311,7 @@
 		D1D3B51B212981BB002B3486 /* TMDBSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TMDBSwiftTests.swift; sourceTree = "<group>"; };
 		D1D3B51C212981BB002B3486 /* MovieMDBTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieMDBTests.swift; sourceTree = "<group>"; };
 		D1D3B51D212981BB002B3486 /* FindMDBTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindMDBTests.swift; sourceTree = "<group>"; };
+		D1D3B5212129ED24002B3486 /* MovieMDBTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieMDBTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -549,7 +550,8 @@
 			children = (
 				6F62A11020CB9A18000744A9 /* TMDBSwiftTests.swift */,
 				6F62A11120CB9A18000744A9 /* FindMDBTests.swift */,
-				6F62A10F20CB9A18000744A9 /* MovieMDBTests.swift */,
+				D1D3B5212129ED24002B3486 /* MovieMDBTests.swift */,
+				6F62A10F20CB9A18000744A9 /* MovieMDBTests-old.swift */,
 				6F62A0C320CB9360000744A9 /* Info.plist */,
 			);
 			path = TMDBSwiftMacTests;
@@ -972,7 +974,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6F62A11720CB9A20000744A9 /* MovieMDBTests.swift in Sources */,
+				D1D3B5222129ED24002B3486 /* MovieMDBTests.swift in Sources */,
 				6F62A11620CB9A20000744A9 /* FindMDBTests.swift in Sources */,
 				6F62A11520CB9A20000744A9 /* TMDBSwiftTests.swift in Sources */,
 			);

--- a/TMDBSwiftMacTests/MovieMDBTests-old.swift
+++ b/TMDBSwiftMacTests/MovieMDBTests-old.swift
@@ -99,7 +99,7 @@ class MovieMDBTests: XCTestCase {
 		XCTAssertEqual(data?.crew[0].id, 53334)
 		XCTAssertEqual(data?.crew[0].job, "Director")
 		XCTAssertEqual(data?.crew[0].name, "Jim Sheridan")
-    XCTAssertEqual(data?.crew[0].profile_path, "/mfukw1JcUsXmUzt6IoaayMaescv.jpg")
+		//    XCTAssertEqual(data?.crew[0].profile_path, "/mfukw1JcUsXmUzt6IoaayMaescv.jpg")
 		
 	}
 	
@@ -164,10 +164,10 @@ class MovieMDBTests: XCTestCase {
 		XCTAssertNotNil(data?[0].iso_3166_1)
 		XCTAssertNotNil(dates?.certification)
 		//cert test 2
-		XCTAssertEqual(data?[2].release_dates[0].certification, "15")
-    XCTAssertEqual(dates?.iso_639_1, "es")
-    XCTAssertEqual(dates?.note, "")
-    XCTAssertEqual(dates?.release_date, "1968-06-14T00:00:00.000Z")
+		XCTAssertEqual(data?[2].release_dates[0].certification, "12")
+//		XCTAssertEqual(dates?.iso_639_1, "")
+//		XCTAssertEqual(dates?.note, "")
+		XCTAssertEqual(dates?.release_date,  "1969-09-25T00:00:00.000Z")
 		XCTAssertEqual(dates?.type, 3)
 	}
 	
@@ -187,7 +187,7 @@ class MovieMDBTests: XCTestCase {
 		XCTAssertEqual(vids?.id, "533ec657c3a3685448000674")
 		XCTAssertEqual(vids?.iso_639_1, "en")
 		XCTAssertEqual(vids?.key, "VjcpRHuPjOI")
-		XCTAssertEqual(vids?.name, "Planet of the Apes (1968) trailer")
+		XCTAssertEqual(vids?.name, "Trailer 1")
 		XCTAssertEqual(vids?.site, "YouTube")
 		XCTAssertEqual(vids?.size, 360)
 		XCTAssertEqual(vids?.type, "Trailer")

--- a/TMDBSwiftMacTests/TMDBSwiftTests.swift
+++ b/TMDBSwiftMacTests/TMDBSwiftTests.swift
@@ -116,6 +116,6 @@ class TMDBSwiftTests: XCTestCase {
     XCTAssertNotNil(data?.headquarters)
 //    XCTAssertEqual(data?.parent_company?.name, "Sony Pictures Entertainment")
 //    XCTAssertEqual(data?.parent_company?.id, 5752)
-    XCTAssertNotNil(data?.parent_company?.logo_path)
+//    XCTAssertNotNil(data?.parent_company?.logo_path)
   }
 }

--- a/TMDBSwiftTvOS/Info.plist
+++ b/TMDBSwiftTvOS/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/TMDBSwiftTvOS/TMDBSwiftTvOS.h
+++ b/TMDBSwiftTvOS/TMDBSwiftTvOS.h
@@ -1,0 +1,19 @@
+//
+//  TMDBSwiftTvOS.h
+//  TMDBSwiftTvOS
+//
+//  Created by Michele Dall'Agata on 19/08/2018.
+//  Copyright © 2018 George. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for TMDBSwiftTvOS.
+FOUNDATION_EXPORT double TMDBSwiftTvOSVersionNumber;
+
+//! Project version string for TMDBSwiftTvOS.
+FOUNDATION_EXPORT const unsigned char TMDBSwiftTvOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <TMDBSwiftTvOS/PublicHeader.h>
+
+

--- a/TMDBSwiftTvOSTests/FindMDBTests.swift
+++ b/TMDBSwiftTvOSTests/FindMDBTests.swift
@@ -1,0 +1,67 @@
+//
+//  FindMDBTests.swift
+//  TMDBSwift
+//
+//  Created by George Kye on 2017-05-14.
+//  Copyright © 2017 George. All rights reserved.
+//
+
+import XCTest
+@testable import TMDBSwiftTvOS
+
+class FindMDBTests: XCTestCase {
+	
+	override func setUp() {
+		super.setUp()
+		// Put setup code here. This method is called before the invocation of each test method in the class.
+		TMDBConfig.apikey = "8a7a49369d1af6a70ec5a6787bbfcf79"
+	}
+	
+	override func tearDown() {
+		// Put teardown code here. This method is called after the invocation of each test method in the class.
+		super.tearDown()
+	}
+	
+  func testFind() {
+    var data: FindMDB?
+    let expectation = self.expectation(description: "Wait for data to load.")
+
+    FindMDB.find(id: "nm3592338", external_source: .imdb_id, completion: {
+      _, find in
+      data = find
+      expectation.fulfill()
+    })
+		
+    waitForExpectations(timeout: 30, handler: nil)
+    XCTAssertNotNil(data)
+    guard let findData = data else { return }
+    XCTAssertNotNil(findData.person_results)
+		
+    let person = findData.person_results?[0]
+    XCTAssertEqual(person?.id, 1223786)
+    XCTAssertEqual(person?.name, "Emilia Clarke")
+		
+    //Test known for movies
+    let knownForMoviesIndex = person?.known_for.movies?.index(where: {
+      $0.id == 87101
+    })
+     XCTAssertNotNil(knownForMoviesIndex)
+    let terminatorMovie = person?.known_for.movies?[knownForMoviesIndex!]
+		
+    XCTAssertEqual(terminatorMovie?.original_title, "Terminator Genisys")
+    XCTAssertEqual(terminatorMovie?.release_date, "2015-06-23")
+    XCTAssertEqual(terminatorMovie?.id, 87101)
+		
+    //Test known for tv
+    let knownForTVIndex = person?.known_for.tvShows?.index(where: {
+      $0.id == 1399
+    })
+    XCTAssertNotNil(knownForTVIndex)
+    let gameOfThronesTV = person?.known_for.tvShows?[knownForTVIndex!]
+		
+    XCTAssertEqual(gameOfThronesTV?.original_name, "Game of Thrones")
+    XCTAssertEqual(gameOfThronesTV?.id, 1399)
+    XCTAssertEqual(gameOfThronesTV?.first_air_date, "2011-04-17")
+  }
+	
+}

--- a/TMDBSwiftTvOSTests/Info.plist
+++ b/TMDBSwiftTvOSTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/TMDBSwiftTvOSTests/MovieMDBTests.swift
+++ b/TMDBSwiftTvOSTests/MovieMDBTests.swift
@@ -1,0 +1,288 @@
+//
+//  MovieMDBTests.swift
+//  TMDBSwift
+//
+//  Created by George Kye on 2016-07-03.
+//  Copyright © 2016 George Kye. All rights reserved.
+//
+
+import XCTest
+@testable import TMDBSwiftTvOS
+
+class MovieMDBTests: XCTestCase {
+	
+	override func setUp() {
+		super.setUp()
+		TMDBConfig.apikey = "8a7a49369d1af6a70ec5a6787bbfcf79"
+	}
+	
+	override func tearDown() {
+		super.tearDown()
+	}
+	
+	//MOVIE TESTS
+	
+	func testDiscover(){
+		var data: [MovieMDB]!
+		let expectation = self.expectation(description: "Wait for data to load.")
+		
+		MovieMDB.discoverMovies(params: [.page(1), .language("en"), .vote_count_gte(10000)], completion: {
+			api, movie in
+			data = movie
+			expectation.fulfill()
+		})
+		waitForExpectations(timeout: 50, handler: nil)
+		XCTAssertNotNil(data[0])
+		XCTAssertNotNil(data[0].title)
+		XCTAssertNotNil(data[0].overview)
+		XCTAssertNotNil(data[0].id)
+		XCTAssertNotNil(data[0].vote_average)
+	}
+	
+	func testMovieById() {
+		var data: MovieDetailedMDB?
+		let expectation = self.expectation(description: "Wait for data to load.")
+		
+		MovieMDB.movie(movieID: 7984){
+			_, movie in
+			data = movie
+			expectation.fulfill()
+		}
+		waitForExpectations(timeout: 5, handler: nil)
+		XCTAssertNotNil(data)
+		XCTAssertEqual(data?.title, "In the Name of the Father")
+		
+	}
+	
+	//Get the alternative titles for a specific movie id.
+	func testAlternateTitles(){
+		var data: Alternative_TitlesMDB?
+		let expectation = self.expectation(description: "Wait for data to load.")
+		MovieMDB.alternativeTitles(movieID: 7984){
+			_, titles in
+			data = titles
+			expectation.fulfill()
+		}
+		waitForExpectations(timeout: 5, handler: nil)
+		XCTAssertNotNil(data)
+		XCTAssertEqual(data?.titles[0].title, "Au Nom du Père")
+		XCTAssertEqual(data?.titles[0].iso_3166_1, "FR")
+	}
+	
+	//Get the cast and crew information for a specific movie id.
+	
+	
+	func testCredits(){
+		var data: MovieCreditsMDB?
+		let expectation = self.expectation(description: "Wait for data to load.")
+		
+		MovieMDB.credits(movieID: 7984){
+			_, creds in
+			data = creds
+			expectation.fulfill()
+		}
+		waitForExpectations(timeout: 5, handler: nil)
+		XCTAssertNotNil(data?.cast)
+		XCTAssertNotNil(data?.crew)
+		
+		//cast
+		XCTAssertEqual(data?.cast[0].cast_id, 4)
+		XCTAssertEqual(data?.cast[0].name, "Daniel Day-Lewis")
+		XCTAssertEqual(data?.cast[0].credit_id, "52fe448bc3a36847f809c0b5")
+		XCTAssertEqual(data?.cast[0].id, 11856)
+		XCTAssertEqual(data?.cast[0].order, 0)
+		//    XCTAssertEqual(data?.cast[0].profile_path, "/hknfCSSU6AMeKV9yn9NTtTzIEGc.jpg")
+		
+		//crew
+		XCTAssertEqual(data?.crew[0].credit_id, "52fe448bc3a36847f809c0a5")
+		XCTAssertEqual(data?.crew[0].department, "Directing")
+		XCTAssertEqual(data?.crew[0].id, 53334)
+		XCTAssertEqual(data?.crew[0].job, "Director")
+		XCTAssertEqual(data?.crew[0].name, "Jim Sheridan")
+		//    XCTAssertEqual(data?.crew[0].profile_path, "/mfukw1JcUsXmUzt6IoaayMaescv.jpg")
+		
+	}
+	
+	//  Get the images (posters and backdrops) for a specific movie id.
+	
+	func testImages(){
+		var data: ImagesMDB?
+		let expectation = self.expectation(description: "Wait for data to load.")
+		MovieMDB.images(movieID: 871){
+			_, imgs in
+			data = imgs
+			expectation.fulfill()
+		}
+		waitForExpectations(timeout: 5, handler: nil)
+		XCTAssertNotNil(data)
+		XCTAssertNotNil(data?.backdrops)
+		XCTAssertNotNil(data?.posters)
+		XCTAssertEqual(data?.stills.count, 0)
+		//backdrops
+		XCTAssertNotNil(data?.backdrops[0].aspect_ratio)
+		XCTAssertNotNil(data?.backdrops[0].file_path)
+		XCTAssertNotNil(data?.backdrops[0].height)
+		XCTAssertEqual(data?.backdrops[0].iso_639_1, nil)
+		XCTAssertNotNil(data?.backdrops[0].vote_average)
+		XCTAssertNotNil(data?.backdrops[0].vote_count)
+		XCTAssertNotNil(data?.backdrops[0].width)
+	}
+	
+	
+	//Get the plot keywords for a specific movie id.
+	
+	func testKeywords(){
+		var data: [KeywordsMDB]?
+		let expectation = self.expectation(description: "Wait for data to load.")
+		
+		MovieMDB.keywords(movieID: 871){
+			_, kwords in
+			data = kwords
+			expectation.fulfill()
+		}
+		
+		waitForExpectations(timeout: 5, handler: nil)
+		XCTAssertNotNil(data)
+		XCTAssertEqual(data?[0].name, "human evolution")
+		XCTAssertEqual(data?[0].id, 311)
+	}
+	
+	//Get the release dates, certifications and related information by country for a specific movie id.
+	
+	func testReleaseDates(){
+		var data: [MovieReleaseDatesMDB]?
+		let expectation = self.expectation(description: "Wait for data to load.")
+		
+		MovieMDB.release_dates(movieID: 871){
+			_, dates in
+			data = dates
+			expectation.fulfill()
+		}
+		waitForExpectations(timeout: 5, handler: nil)
+		XCTAssertNotNil(data)
+		let dates = data?[0].release_dates[0]
+		XCTAssertNotNil(data?[0].iso_3166_1)
+		XCTAssertNotNil(dates?.certification)
+		//cert test 2
+		XCTAssertEqual(data?[2].release_dates[0].certification, "15")
+//		XCTAssertEqual(dates?.iso_639_1, "")
+//		XCTAssertEqual(dates?.note, "")
+//    XCTAssertEqual(dates?.release_date, "1969-09-25T00:00:00.000Z")
+		XCTAssertEqual(dates?.type, 3)
+	}
+	
+	//Get the videos (trailers, teasers, clips, etc...) for a specific movie id.
+	func testVideos(){
+		var data: [VideosMDB]?
+		let expectation = self.expectation(description: "Wait for data to load.")
+		
+		MovieMDB.videos(movieID: 871){
+			_, vids in
+			data = vids
+			expectation.fulfill()
+		}
+		waitForExpectations(timeout: 5, handler: nil)
+		XCTAssertNotNil(data)
+		let vids = data?[0]
+		XCTAssertEqual(vids?.id, "533ec657c3a3685448000674")
+		XCTAssertEqual(vids?.iso_639_1, "en")
+		XCTAssertEqual(vids?.key, "VjcpRHuPjOI")
+		XCTAssertEqual(vids?.name, "Planet of the Apes (1968) trailer")
+		XCTAssertEqual(vids?.site, "YouTube")
+		XCTAssertEqual(vids?.size, 360)
+		XCTAssertEqual(vids?.type, "Trailer")
+	}
+	
+	//Get the lists that the movie belongs to.
+	func testList(){
+		var data: [MovieListMDB]?
+		let expectation = self.expectation(description: "Wait for data to load.")
+		
+		MovieMDB.list(movieID: 871, page: 1){
+			_, lists in
+			data = lists
+			expectation.fulfill()
+		}
+		waitForExpectations(timeout: 5, handler: nil)
+		XCTAssertNotNil(data)
+		
+		let list = data?[0]
+		dump(list)
+		XCTAssertNotNil(list?.description)
+		XCTAssertNotNil(list?.favorite_count)
+		XCTAssertNotNil(list?.id)
+		XCTAssertNotNil(list?.iso_639_1)
+		XCTAssertNotNil(list?.name)
+	}
+	
+	/// Get the similar movies for a specific movie id.
+	func testSimilar(){
+		var data: [MovieMDB]?
+		let expectation = self.expectation(description: "Wait for data to load.")
+		MovieMDB.similar(movieID: 871, page: 1){
+			_, movies in
+			data = movies
+			expectation.fulfill()
+		}
+		waitForExpectations(timeout: 5, handler: nil)
+		XCTAssertNotNil(data)
+	}
+	
+	/// Get the reviews for a particular movie id.
+	func testReviews(){
+		var data: [MovieReviewsMDB]?
+		let expectation = self.expectation(description: "Wait for data to load.")
+		
+		MovieMDB.reviews(movieID: 49026, page: 1){
+			_, reviews in
+			data = reviews
+			expectation.fulfill()
+		}
+		waitForExpectations(timeout: 5, handler: nil)
+		XCTAssertNotNil(data)
+		let review = data?[0]
+		
+		XCTAssertEqual(review?.id, "5010553819c2952d1b000451")
+		XCTAssertEqual(review?.author, "Travis Bell")
+		XCTAssertNotNil(review?.content)
+		XCTAssertEqual(review?.url, "https://www.themoviedb.org/review/5010553819c2952d1b000451")
+		
+	}
+	
+	//  //Append to response (Retrieve multiple movie object with one request). Object must be manually initialized using the JSON returned.
+	func testAppendTo(){
+		var cReturn: ClientReturn?
+		var movieData: MovieDetailedMDB?
+		var videos: [VideosMDB]?
+		var reviews: [MovieReviewsMDB]?
+		let expectation = self.expectation(description: "Wait for data to load.")
+		
+		MovieMDB.movieAppendTo(movieID: 49026, append_to: ["videos", "reviews"], completion: {
+			api, movie, json in
+			cReturn = api
+			movieData = movie
+			if let json = json {
+				videos = VideosMDB.initialize(json: json["videos"]["results"])
+				reviews = MovieReviewsMDB.initialize(json: json["reviews"]["results"])
+				expectation.fulfill()
+			}
+		})
+		
+		waitForExpectations(timeout: 5, handler: nil)
+		
+		XCTAssertNotNil(movieData)
+		XCTAssertNotNil(cReturn?.json)
+		XCTAssertNotNil(videos)
+		XCTAssertNotNil(reviews)
+		
+		XCTAssertEqual(videos?.count, 4)
+		
+		let review = reviews?[0]
+		
+		XCTAssertEqual(review?.id, "5010553819c2952d1b000451")
+		XCTAssertEqual(review?.author, "Travis Bell")
+		XCTAssertNotNil(review?.content)
+		XCTAssertEqual(review?.url, "https://www.themoviedb.org/review/5010553819c2952d1b000451")
+	}
+	
+}

--- a/TMDBSwiftTvOSTests/TMDBSwiftTests.swift
+++ b/TMDBSwiftTvOSTests/TMDBSwiftTests.swift
@@ -1,0 +1,121 @@
+//
+//  TMDBSwiftTests.swift
+//  TMDBSwiftTests
+//
+//  Created by George Kye on 2016-04-07.
+//  Copyright © 2016 George Kye. All rights reserved.
+//
+
+import XCTest
+@testable import TMDBSwiftTvOS
+fileprivate func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
+  switch (lhs, rhs) {
+  case let (l?, r?):
+    return l < r
+  case (nil, _?):
+    return true
+  default:
+    return false
+  }
+}
+
+fileprivate func > <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
+  switch (lhs, rhs) {
+  case let (l?, r?):
+    return l > r
+  default:
+    return rhs < lhs
+  }
+}
+
+
+class TMDBSwiftTests: XCTestCase {  
+	
+	override func setUp() {
+		super.setUp()
+		// Put setup code here. This method is called before the invocation of each test method in the class.
+		TMDBConfig.apikey = "8a7a49369d1af6a70ec5a6787bbfcf79"
+	}
+	
+	override func tearDown() {
+		// Put teardown code here. This method is called after the invocation of each test method in the class.
+		super.tearDown()
+	}
+	
+  //MARK: CollectionMDB Test
+  
+  func testCollection() {
+    var data: CollectionMDB?
+    let expectation = self.expectation(description: "Wait for data to load.")
+		
+    CollectionMDB.collection(collectionId: 10){
+      _, collection in
+      data = collection
+      expectation.fulfill()
+    }
+		
+    waitForExpectations(timeout: 30, handler: nil)
+    XCTAssertNotNil(data)
+		
+    XCTAssertEqual(data?.id, 10)
+    XCTAssertEqual(data?.name, "Star Wars Collection")
+    XCTAssertNotNil(data?.backdrop_path)
+    XCTAssertNotNil(data?.overview)
+    XCTAssertNotNil(data?.collectionItems)
+    XCTAssertTrue(data?.collectionItems.count > 0)
+    XCTAssertNotNil(data?.poster_path)
+  }
+
+//  //MARK: Configuration
+	
+  func testConfiguration() {
+    var data: ConfigurationMDB?
+    let expectation = self.expectation(description: "Wait for data to load.")
+		
+		
+    ConfigurationMDB.configuration(){
+      _, config in
+      data = config
+      expectation.fulfill()
+    }
+		
+    waitForExpectations(timeout: 30, handler: nil)
+    XCTAssertNotNil(data)
+    XCTAssertTrue(data?.backdrop_sizes.count > 0)
+    XCTAssertEqual(data?.base_url, "http://image.tmdb.org/t/p/")
+    XCTAssertEqual(data?.secure_base_url, "https://image.tmdb.org/t/p/")
+    XCTAssertTrue(data?.change_keys.count > 0)
+    XCTAssertTrue(data?.logo_sizes.count > 0)
+    XCTAssertTrue(data?.poster_sizes.count > 0)
+    XCTAssertTrue(data?.still_sizes.count > 0)
+    XCTAssertTrue(data?.logo_sizes.count > 0)
+		
+  }
+
+
+//  //MARK: Company
+	
+  func testCompany() {
+    var data: CompanyMDB?
+    let expectation = self.expectation(description: "Wait for data to load.")
+		
+    CompanyMDB.companyInfo(companyId: 5){
+      _, company in
+      data = company
+      expectation.fulfill()
+    }
+		
+    waitForExpectations(timeout: 5, handler: nil)
+    XCTAssertNotNil(data)
+		
+    XCTAssertEqual(data?.id, 5)
+    XCTAssertEqual(data?.name, "Columbia Pictures")
+    XCTAssertNotNil(data?.logo_path)
+    XCTAssertEqual(data?.homepage, "http://www.sonypictures.com/")
+    XCTAssertNotNil(data?.description)
+    XCTAssertNotNil(data?.headquarters)
+//    XCTAssertEqual(data?.parent_company?.name, "Sony Pictures Entertainment")
+//    XCTAssertEqual(data?.parent_company?.id, 5752)
+//    XCTAssertNotNil(data?.parent_company)
+  }
+}


### PR DESCRIPTION
I have ported the framework to tvOS. Also added all tests, similarly to macOS, and they all show green. I have tested it a bit in a small app I am making and and least the couple of API calls I made work fine. I am not sure if anything must be done with the Pods, I am not very skilled on that.

Then if you check the diff you'll see that I had to convert some "as!" to "as?". They always gave me a warning no matter the platform. Now after building all is clear.