### PR TITLE
adult property was part of DiscoverMDB but only initialized in Discov…

### DIFF
--- a/Sources/Models/Discover/Discover.swift
+++ b/Sources/Models/Discover/Discover.swift
@@ -55,7 +55,6 @@ public enum DiscoverParam {
 }
 
 open class DiscoverMDB: ArrayObject {
-	open var adult: Bool!
 	open var overview: String?
 	open var popularity: Double?
 	open var id: Int!

--- a/Sources/Models/Discover/DiscoverMovie.swift
+++ b/Sources/Models/Discover/DiscoverMovie.swift
@@ -54,6 +54,7 @@ public enum DiscoverSortByMovie: String {
 open class DiscoverMovieMDB: DiscoverMDB{
   open var title: String?
   open var video: Bool?
+  open var adult: Bool?
   open var release_date: String?
   open var original_title: String?
   open var genreIds: [Int]?

--- a/Sources/Models/FindMDB.swift
+++ b/Sources/Models/FindMDB.swift
@@ -19,35 +19,20 @@ public enum ExternalIdTypes: String{
   case id
 }
 
-open class KnownForMovie: DiscoverMDB{
-  open var original_title: String?
-  open var release_date: String?
-  open var title: String!
-  open var video: Bool!
+open class KnownForMovie: DiscoverMovieMDB {
   open var media_type: String!
   
   required public init(results: JSON) {
     super.init(results: results)
-    original_title = results["original_title"].string
-    release_date = results["release_date"].string
-    title = results["title"].string
     media_type = results["media_type"].string
   }
 }
 
-open class KnownForTV: DiscoverMDB{
-  open var original_name: String?
-  open var origin_country: [String]?
-  open var first_air_date: String?
-  open var name: String!
+open class KnownForTV: DiscoverTVMDB{
   open var media_type: String!
   
   required public init(results: JSON) {
     super.init(results: results)
-    original_name = results["original_name"].string
-    origin_country = results["origin_country"].arrayObject as? [String]
-    first_air_date = results["first_air_date"].string
-    name = results["name"].string
     media_type = results["media_type"].string
   }
   


### PR DESCRIPTION
…erMovieMDB

DiscoverTV and KnownForTV does not have `adult` property so it makes more sense to inherit it from DiscoverMovieMDB downwards
additionally, KnownForTV and KnownForMovie seem to take the properties of DiscoverTVMDB and DiscoverMovieMDB when comparing the API documentation, so I made them inherit respectively

Edit: 
Please let me know if I should do the pull requests differently. 
Or if I should make them against another branch instead of master.