### PR TITLE
Fix ChangesMDB change type

### DIFF
--- a/Sources/Models/ChangesMDB.swift
+++ b/Sources/Models/ChangesMDB.swift
@@ -27,9 +27,25 @@ public struct ChangesMDB{
     }
     return changes
   }
-  
-  public static func changes(changeType: String, page: Double?, startDate: String? = nil, endDate:String? = nil, completionHandler: @escaping (_ clientReturn: ClientReturn, _ data: [ChangesMDB]?) -> ()) -> (){
-    Client.Changes(changeType: "movie", page: 1, startDate: nil, endDate: nil){
+
+    public enum ChangeType: String {
+        case movie, tv, person
+    }
+
+    public static func changes(changeType: ChangeType, page: Int? = 1, startDate: String? = nil, endDate:String? = nil, completionHandler: @escaping (_ clientReturn: ClientReturn, _ data: [ChangesMDB]?) -> ()) -> (){
+        Client.Changes(changeType: changeType.rawValue, page: page, startDate: startDate, endDate: endDate){
+            apiReturn in
+            var changes: [ChangesMDB]?
+            if let results = apiReturn.json?["results"] {
+                changes = ChangesMDB.initReturn(results)
+            }
+            completionHandler(apiReturn, changes)
+        }
+    }
+
+  public static func changes(changeType: String, page: Double? = nil, startDate: String? = nil, endDate:String? = nil, completionHandler: @escaping (_ clientReturn: ClientReturn, _ data: [ChangesMDB]?) -> ()) -> (){
+    let pageValue: Int? = page != nil ? Int(page!) : nil
+    Client.Changes(changeType: changeType, page: pageValue, startDate: startDate, endDate: endDate){
       apiReturn in
       var changes: [ChangesMDB]?
       if let results = apiReturn.json?["results"] {

--- a/Sources/Models/ChangesMDB.swift
+++ b/Sources/Models/ChangesMDB.swift
@@ -32,7 +32,7 @@ public struct ChangesMDB{
         case movie, tv, person
     }
 
-    public static func changes(changeType: ChangeType, page: Int? = 1, startDate: String? = nil, endDate:String? = nil, completionHandler: @escaping (_ clientReturn: ClientReturn, _ data: [ChangesMDB]?) -> ()) -> (){
+    public static func changes(type changeType: ChangeType, page: Int? = 1, startDate: String? = nil, endDate:String? = nil, completionHandler: @escaping (_ clientReturn: ClientReturn, _ data: [ChangesMDB]?) -> ()) -> (){
         Client.Changes(changeType: changeType.rawValue, page: page, startDate: startDate, endDate: endDate){
             apiReturn in
             var changes: [ChangesMDB]?
@@ -43,14 +43,11 @@ public struct ChangesMDB{
         }
     }
 
+  @available(*, deprecated, renamed: "changes(type:page:startDate:endDate:completionHandler:)")
   public static func changes(changeType: String, page: Double? = nil, startDate: String? = nil, endDate:String? = nil, completionHandler: @escaping (_ clientReturn: ClientReturn, _ data: [ChangesMDB]?) -> ()) -> (){
     let pageValue: Int? = page != nil ? Int(page!) : nil
-    Client.Changes(changeType: changeType, page: pageValue, startDate: startDate, endDate: endDate){
-      apiReturn in
-      var changes: [ChangesMDB]?
-      if let results = apiReturn.json?["results"] {
-        changes = ChangesMDB.initReturn(results)
-      }
+
+    changes(type: ChangeType(rawValue: changeType) ?? .movie, page: pageValue, startDate: startDate, endDate: endDate) { apiReturn, changes in
       completionHandler(apiReturn, changes)
     }
   }

--- a/TMDBSwift.xcodeproj/project.pbxproj
+++ b/TMDBSwift.xcodeproj/project.pbxproj
@@ -71,6 +71,9 @@
 		5EF1B3751CB732C900B49F4E /* TVMDBModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B33F1CB732C900B49F4E /* TVMDBModel.swift */; };
 		5EF1B3761CB732C900B49F4E /* TVSeasonsMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3401CB732C900B49F4E /* TVSeasonsMDB.swift */; };
 		5EF1B3771CB732C900B49F4E /* VideosMDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF1B3411CB732C900B49F4E /* VideosMDB.swift */; };
+		6E34E87521721DF000174B31 /* ChangesMDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E34E87421721DF000174B31 /* ChangesMDBTests.swift */; };
+		6E34E87621721DF000174B31 /* ChangesMDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E34E87421721DF000174B31 /* ChangesMDBTests.swift */; };
+		6E34E87721721DF000174B31 /* ChangesMDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E34E87421721DF000174B31 /* ChangesMDBTests.swift */; };
 		6F62A0BD20CB9360000744A9 /* TMDBSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F62A0B420CB935F000744A9 /* TMDBSwift.framework */; };
 		6F62A0C420CB9360000744A9 /* TMDBSwift-macOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F62A0B620CB935F000744A9 /* TMDBSwift-macOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6F62A0D420CB9471000744A9 /* ArrayObjectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF143611CF0A3FB009C620D /* ArrayObjectProtocol.swift */; };
@@ -295,6 +298,7 @@
 		5EF1B3411CB732C900B49F4E /* VideosMDB.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideosMDB.swift; sourceTree = "<group>"; };
 		5EF1B37A1CB73D6B00B49F4E /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = "../../Library/Developer/Xcode/DerivedData/TMDBSwift-ctqadmatvtticcbrgqcmawytsfdg/Build/Products/Debug-iphonesimulator/Alamofire/Alamofire.framework"; sourceTree = "<group>"; };
 		5EF1B37C1CB73D7100B49F4E /* SwiftyJSON.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyJSON.framework; path = "../../Library/Developer/Xcode/DerivedData/TMDBSwift-ctqadmatvtticcbrgqcmawytsfdg/Build/Products/Debug-iphonesimulator/SwiftyJSON/SwiftyJSON.framework"; sourceTree = "<group>"; };
+		6E34E87421721DF000174B31 /* ChangesMDBTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesMDBTests.swift; sourceTree = "<group>"; };
 		6F62A0B420CB935F000744A9 /* TMDBSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TMDBSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F62A0B620CB935F000744A9 /* TMDBSwift-macOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TMDBSwift-macOS.h"; sourceTree = "<group>"; };
 		6F62A0B720CB935F000744A9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -452,6 +456,7 @@
 				5EF1B27A1CB72DC000B49F4E /* TMDBSwiftTests.swift */,
 				185D4CAA1EC924DA0083D85A /* FindMDBTests.swift */,
 				5E4CC87A1D295BC700101495 /* MovieMDBTests.swift */,
+				6E34E87421721DF000174B31 /* ChangesMDBTests.swift */,
 			);
 			path = TMDBSwiftTests;
 			sourceTree = "<group>";
@@ -872,6 +877,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6E34E87521721DF000174B31 /* ChangesMDBTests.swift in Sources */,
 				185D4CAB1EC924DA0083D85A /* FindMDBTests.swift in Sources */,
 				5E4CC87B1D295BC700101495 /* MovieMDBTests.swift in Sources */,
 				5EF1B27B1CB72DC000B49F4E /* TMDBSwiftTests.swift in Sources */,
@@ -948,6 +954,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6E34E87621721DF000174B31 /* ChangesMDBTests.swift in Sources */,
 				D165CA4921410C33000274F3 /* MovieMDBTests.swift in Sources */,
 				D165CA4821410C33000274F3 /* FindMDBTests.swift in Sources */,
 				D165CA4721410C33000274F3 /* TMDBSwiftTests.swift in Sources */,
@@ -1024,6 +1031,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6E34E87721721DF000174B31 /* ChangesMDBTests.swift in Sources */,
 				D165CA4C21410C34000274F3 /* MovieMDBTests.swift in Sources */,
 				D165CA4B21410C34000274F3 /* FindMDBTests.swift in Sources */,
 				D165CA4A21410C34000274F3 /* TMDBSwiftTests.swift in Sources */,

--- a/TMDBSwiftTests/ChangesMDBTests.swift
+++ b/TMDBSwiftTests/ChangesMDBTests.swift
@@ -1,0 +1,51 @@
+//
+//  PersonMDBTests.swift
+//  TMDBSwift-iOS
+//
+//  Created by Martin Pfundmair on 2018-10-13.
+//  Copyright © 2018 George. All rights reserved.
+//
+
+import XCTest
+@testable import TMDBSwift
+
+class ChangesMDBTests: XCTestCase {
+
+  let expecationTimeout: TimeInterval = 50
+
+  override func setUp() {
+    super.setUp()
+    TMDBConfig.apikey = "8a7a49369d1af6a70ec5a6787bbfcf79"
+  }
+
+  override func tearDown() {
+    super.tearDown()
+  }
+
+  func testChanges() {
+    var data: [ChangesMDB]!
+    let expectation = self.expectation(description: "Wait for data to load.")
+
+    ChangesMDB.changes(changeType: "movie") { api, responseData in
+      data = responseData
+      expectation.fulfill()
+    }
+    waitForExpectations(timeout: expecationTimeout, handler: nil)
+    XCTAssertNotNil(data.first?.id)
+    XCTAssertNotNil(data.first?.adult)
+  }
+
+  func testChangesNew() {
+    var data: [ChangesMDB]!
+    let expectation = self.expectation(description: "Wait for data to load.")
+
+    ChangesMDB.changes(changeType: .movie) { api, responseData in
+      data = responseData
+      expectation.fulfill()
+    }
+    waitForExpectations(timeout: expecationTimeout, handler: nil)
+    XCTAssertNotNil(data.first?.id)
+    XCTAssertNotNil(data.first?.adult)
+  }
+
+}

--- a/TMDBSwiftTests/ChangesMDBTests.swift
+++ b/TMDBSwiftTests/ChangesMDBTests.swift
@@ -35,11 +35,11 @@ class ChangesMDBTests: XCTestCase {
     XCTAssertNotNil(data.first?.adult)
   }
 
-  func testChangesNew() {
+  func testChangesWithEnum() {
     var data: [ChangesMDB]!
     let expectation = self.expectation(description: "Wait for data to load.")
 
-    ChangesMDB.changes(changeType: .movie) { api, responseData in
+    ChangesMDB.changes(type: .movie) { api, responseData in
       data = responseData
       expectation.fulfill()
     }
@@ -48,4 +48,19 @@ class ChangesMDBTests: XCTestCase {
     XCTAssertNotNil(data.first?.adult)
   }
 
+  func testChangesWithParam() {
+    var data: [ChangesMDB]!
+    var api: ClientReturn!
+    let expectation = self.expectation(description: "Wait for data to load.")
+
+    ChangesMDB.changes(type: .tv, page: 2) { responseApi, responseData in
+      api = responseApi
+      data = responseData
+      expectation.fulfill()
+    }
+    waitForExpectations(timeout: expecationTimeout, handler: nil)
+    XCTAssertNotNil(data.first?.id)
+    XCTAssertNotNil(data.first?.adult)
+    XCTAssertEqual(api.pageResults?.page, 2)
+  }
 }


### PR DESCRIPTION
The parameters were ignored by the method itself.  
I replaced the method signature and add an enum for convenience, tests and deprecated the old one so it will be auto-fixed by Xcode.