### PR TITLE
Support next_episodes_to_air and last_episodes_to_air properties

### DIFF
--- a/Sources/Models/TVDetailedMDB.swift
+++ b/Sources/Models/TVDetailedMDB.swift
@@ -55,7 +55,9 @@ open class TVDetailedMDB: TVMDB{
   open var seasons = [tv_seasons]()
   open var status: String!
   open var type: String!
-  
+  open var nextEpisodeToAir: TVEpisodesMDB?
+  open var lastEpisodeToAir: TVEpisodesMDB?
+
   required public init(results: JSON) {
     super.init(results: results)
     if(results["created_by"].count > 0 && results["created_by"][0].exists()){
@@ -95,6 +97,14 @@ open class TVDetailedMDB: TVMDB{
     
     status = results["status"].string
     type = results["type"].string
+    
+    if results["last_episode_to_air"].count > 0 {
+        lastEpisodeToAir = TVEpisodesMDB.init(results: results["last_episode_to_air"])
+    }
+
+    if results["next_episode_to_air"].count > 0 {
+        nextEpisodeToAir = TVEpisodesMDB.init(results: results["next_episode_to_air"])
+    }
   }
   
 }


### PR DESCRIPTION
Add support of last_episode_to_air and next_episode_to_air object on TVDetailedMDB model

The two properties were aded the July 17, 2018 according to the documentation https://developers.themoviedb.org/3/tv/get-tv-details