### PR TITLE
Clean up warnings and broken tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ Replace SwiftyJSON with swift4's Codeable
 2. View <a href="https://github.com/gkye/TheMovieDatabaseSwiftWrapper/wiki">Wikis</a> for examples 
 <br>
 
-To run the example project, clone the repo, and run `pod install` from the Demo directory first.
-
 ## Installation
 
 TMDBSwift is available through [CocoaPods](http://cocoapods.org). To install

--- a/Sources/TMDBSwift/Protocols/ArrayObjectProtocol.swift
+++ b/Sources/TMDBSwift/Protocols/ArrayObjectProtocol.swift
@@ -13,11 +13,10 @@ public protocol ArrayObject {
   init(results: JSON)
 }
 
-public extension ArrayObject {
-  
-  public static func initialize<T:ArrayObject>(json: JSON) -> [T] {
+public extension ArrayObject {c
+  static func initialize<T:ArrayObject>(json: JSON) -> [T] {
     var array = [T]()
-		
+
     json.forEach(){
       array.append(T.init(results: $0.1))
     }

--- a/Sources/TMDBSwift/Protocols/ArrayObjectProtocol.swift
+++ b/Sources/TMDBSwift/Protocols/ArrayObjectProtocol.swift
@@ -13,7 +13,7 @@ public protocol ArrayObject {
   init(results: JSON)
 }
 
-public extension ArrayObject {c
+public extension ArrayObject {
   static func initialize<T:ArrayObject>(json: JSON) -> [T] {
     var array = [T]()
 

--- a/Tests/TMDBSwiftTests/FindMDBTests.swift
+++ b/Tests/TMDBSwiftTests/FindMDBTests.swift
@@ -42,7 +42,7 @@ class FindMDBTests: XCTestCase {
     XCTAssertEqual(person?.name, "Emilia Clarke")
 		
     //Test known for movies
-    let knownForMoviesIndex = person?.known_for.movies?.index(where: {
+    let knownForMoviesIndex = person?.known_for.movies?.firstIndex(where: {
       $0.id == 87101
     })
      XCTAssertNotNil(knownForMoviesIndex)
@@ -53,7 +53,7 @@ class FindMDBTests: XCTestCase {
     XCTAssertEqual(terminatorMovie?.id, 87101)
 		
     //Test known for tv
-    let knownForTVIndex = person?.known_for.tvShows?.index(where: {
+    let knownForTVIndex = person?.known_for.tvShows?.firstIndex(where: {
       $0.id == 1399
     })
     XCTAssertNotNil(knownForTVIndex)

--- a/Tests/TMDBSwiftTests/MovieMDBTests.swift
+++ b/Tests/TMDBSwiftTests/MovieMDBTests.swift
@@ -286,7 +286,7 @@ class MovieMDBTests: XCTestCase {
 		XCTAssertNotNil(videos)
 		XCTAssertNotNil(reviews)
 		
-		XCTAssertEqual(videos?.count, 4)
+		XCTAssertEqual(videos?.count, 9)
 		
 		let review = reviews?[0]
 		


### PR DESCRIPTION
Just some clean up work.

- Removing references to the missing `Demo` app, they can always be added later as part of a new demo app
- Fixing a few warnings
- Updating a failing integration test

Closes: https://github.com/gkye/TheMovieDatabaseSwiftWrapper/issues/61
Also closes https://github.com/gkye/TheMovieDatabaseSwiftWrapper/issues/31 as it's irrelevant at this point.