### PR TITLE
Properly init arrays of MovieDetailedMDB

### DIFF
--- a/Sources/TMDBSwift/Models/MovieDetailedMDB.swift
+++ b/Sources/TMDBSwift/Models/MovieDetailedMDB.swift
@@ -35,11 +35,11 @@ open class MovieDetailedMDB: MovieMDB {
   open var budget: Int?
   open var homepage: String?
   open var imdb_id: Int!
-  open var production_companies: [KeywordsMDB]?
-  open var production_countries: [KeywordsMDB]?
+  open var production_companies: [KeywordsMDB]? = []
+  open var production_countries: [KeywordsMDB]? = []
   open var revenue : Int?
   open var runtime: Int?
-  open var spoken_languages: [SpokenLanguages]?
+  open var spoken_languages: [SpokenLanguages]? = []
   open var status: String!
   open var tagline: String!
   


### PR DESCRIPTION
Fixing the issue mentioned in: https://github.com/gkye/TheMovieDatabaseSwiftWrapper/pull/48

> Arrays were never initiated, the values were always nil

With the code changes suggestion mentioned it the comments. 

Closes: https://github.com/gkye/TheMovieDatabaseSwiftWrapper/issues/51