### PR TITLE
Add tests for TVSeasonsMDB

### DIFF
--- a/Sources/TMDBSwift/Models/CastCrewMDB.swift
+++ b/Sources/TMDBSwift/Models/CastCrewMDB.swift
@@ -36,6 +36,18 @@ open class CrewMDB: CastCrewCommonMDB {
 open class TVCastMDB: CastCrewCommonMDB {
     open var character: String!
     open var order: Int!
+
+    enum CodingKeys: String, CodingKey {
+        case character
+        case order
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        character = try? container.decode(String?.self, forKey: .character)
+        order = try? container.decode(Int?.self, forKey: .order)
+        try super.init(from: decoder)
+    }
 }
 
 open class TVCreditsMDB: Decodable {

--- a/Sources/TMDBSwift/Models/ImagesMDB.swift
+++ b/Sources/TMDBSwift/Models/ImagesMDB.swift
@@ -20,9 +20,9 @@ open class ImageMDB: Decodable {
 }
 
 public struct ImagesMDB: Decodable {
-    public var backdrops = [ImageMDB]()
-    public var posters = [ImageMDB]()
-    public var stills = [ImageMDB]()
+    public var backdrops: [ImageMDB]?
+    public var posters: [ImageMDB]?
+    public var stills: [ImageMDB]?
     public var id: Int!
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/TMDBSwift/Models/TVEpisodesMDB.swift
+++ b/Sources/TMDBSwift/Models/TVEpisodesMDB.swift
@@ -10,18 +10,18 @@ import Foundation
 
 public struct TVEpisodesMDB: Decodable {
 
-    public var air_date: String!
-    public var crew = [CrewMDB]()
-    public var guest_stars = [TVCastMDB]()
-    public var episode_number: Int!
-    public var name: String!
-    public var overview: String!
-    public var id: Int!
-    public var production_code: Int!
-    public var season_number: Int!
-    public var still_path: String!
-    public var vote_average: Int!
-    public var vote_count: Int!
+    public var air_date: String?
+    public var crew: [CrewMDB]?
+    public var guest_stars: [TVCastMDB]?
+    public var episode_number: Int?
+    public var name: String?
+    public var overview: String?
+    public var id: Int?
+    public var production_code: String?
+    public var season_number: Int?
+    public var still_path: String?
+    public var vote_average: Double?
+    public var vote_count: Int?
 
     /// Get the primary information about a TV episode by combination of a season and episode number.
     public static func episode_number(tvShowId: Int!, seasonNumber: Int!, episodeNumber: Int!, language: String?, completion: @escaping (_ clientReturn: ClientReturn, _ data: TVEpisodesMDB?) -> Void) {

--- a/Sources/TMDBSwift/Models/TVSeasonsMDB.swift
+++ b/Sources/TMDBSwift/Models/TVSeasonsMDB.swift
@@ -10,13 +10,13 @@ import Foundation
 
 public struct TVSeasonsMDB: Decodable {
 
-    public var air_date: String!
-    public var episodes = [TVEpisodesMDB]()
-    public var name: String!
-    public var overview: String!
-    public var id: Int!
-    public var poster_path: String!
-    public var season_number: Int!
+    public var air_date: String?
+    public var episodes: [TVEpisodesMDB]?
+    public var name: String?
+    public var overview: String?
+    public var id: Int?
+    public var poster_path: String?
+    public var season_number: Int?
 
     /// Get the primary information about a TV season by its season number.
     public static func season_number(tvShowId: Int!, seasonNumber: Int!, language: String?, completion: @escaping (_ clientReturn: ClientReturn, _ data: TVSeasonsMDB?) -> Void) {
@@ -39,7 +39,7 @@ public struct TVSeasonsMDB: Decodable {
     }
 
     /// Get the external ids that we have stored for a TV season by season number.
-    public static func externalIDS(tvShowId: Int!, seasonNumber: Int!, language: String, completion: @escaping (_ clientReturn: ClientReturn, _ data: ExternalIdsMDB?) -> Void) {
+    public static func externalIDS(tvShowId: Int!, seasonNumber: Int!, language: String?, completion: @escaping (_ clientReturn: ClientReturn, _ data: ExternalIdsMDB?) -> Void) {
         let urltype = String(tvShowId) + "/season/" + String(seasonNumber) + "/external_ids"
         Client.Seasons(urltype, language: language) { apiReturn in
             let data: ExternalIdsMDB? = apiReturn.decode()
@@ -48,7 +48,7 @@ public struct TVSeasonsMDB: Decodable {
     }
 
     /// Get the images (posters) that we have stored for a TV season by season number. **[backdrops] returned in ImagesMDB will be `nil`
-    public static func images(tvShowId: Int!, seasonNumber: Int!, language: String, completion: @escaping (_ clientReturn: ClientReturn, _ data: ImagesMDB?) -> Void) {
+    public static func images(tvShowId: Int!, seasonNumber: Int!, language: String?, completion: @escaping (_ clientReturn: ClientReturn, _ data: ImagesMDB?) -> Void) {
         let urltype = String(tvShowId) + "/season/" + String(seasonNumber) + "/images"
         Client.Seasons(urltype, language: language) { apiReturn in
             let data: ImagesMDB? = apiReturn.decode()
@@ -57,7 +57,7 @@ public struct TVSeasonsMDB: Decodable {
     }
 
     /// Get the videos that have been added to a TV season (trailers, teasers, etc...)
-    public static func videos(tvShowId: Int!, seasonNumber: Int!, language: String, completion: @escaping (_ clientReturn: ClientReturn, _ data: [VideosMDB]?) -> Void) {
+    public static func videos(tvShowId: Int!, seasonNumber: Int!, language: String?, completion: @escaping (_ clientReturn: ClientReturn, _ data: [VideosMDB]?) -> Void) {
         //     [/tv/11/season/1/credits]
         let urltype = String(tvShowId) + "/season/" + String(seasonNumber) + "/videos"
         Client.Seasons(urltype, language: language) { apiReturn in

--- a/Tests/TMDBSwiftTests/MovieMDBTests.swift
+++ b/Tests/TMDBSwiftTests/MovieMDBTests.swift
@@ -112,15 +112,15 @@ final class MovieMDBTests: XCTestCase {
         XCTAssertNotNil(data)
         XCTAssertNotNil(data?.backdrops)
         XCTAssertNotNil(data?.posters)
-        XCTAssertEqual(data?.stills.count, 4)
+        XCTAssertEqual(data?.stills?.count ?? 0, 4)
         // backdrops
-        XCTAssertNotNil(data?.backdrops[0].aspect_ratio)
-        XCTAssertNotNil(data?.backdrops[0].file_path)
-        XCTAssertNotNil(data?.backdrops[0].height)
-        XCTAssertEqual(data?.backdrops[0].iso_639_1, nil)
-        XCTAssertNotNil(data?.backdrops[0].vote_average)
-        XCTAssertNotNil(data?.backdrops[0].vote_count)
-        XCTAssertNotNil(data?.backdrops[0].width)
+        XCTAssertNotNil(data?.backdrops?[0].aspect_ratio)
+        XCTAssertNotNil(data?.backdrops?[0].file_path)
+        XCTAssertNotNil(data?.backdrops?[0].height)
+        XCTAssertEqual(data?.backdrops?[0].iso_639_1, nil)
+        XCTAssertNotNil(data?.backdrops?[0].vote_average)
+        XCTAssertNotNil(data?.backdrops?[0].vote_count)
+        XCTAssertNotNil(data?.backdrops?[0].width)
     }
 
     // Get the plot keywords for a specific movie id.

--- a/Tests/TMDBSwiftTests/TVMDBTests.swift
+++ b/Tests/TMDBSwiftTests/TVMDBTests.swift
@@ -111,11 +111,11 @@ final class TVMDBTests: XCTestCase {
 
         waitForExpectations(timeout: expecationTimeout, handler: nil)
         XCTAssertEqual(data.id, 1399)
-        XCTAssertTrue(data.backdrops.count > 0)
-        XCTAssertTrue(data.posters.count > 0)
-        XCTAssertNotNil(data.posters.first?.file_path)
-        XCTAssertNotNil(data.posters.first?.height)
-        XCTAssertNotNil(data.posters.first?.width)
+        XCTAssertTrue(data.backdrops?.count ?? -1 > 0)
+        XCTAssertTrue(data.posters?.count ?? -1 > 0)
+        XCTAssertNotNil(data.posters?.first?.file_path)
+        XCTAssertNotNil(data.posters?.first?.height)
+        XCTAssertNotNil(data.posters?.first?.width)
     }
 
     func testKeywords() {

--- a/Tests/TMDBSwiftTests/TVSeasonsMDBTests.swift
+++ b/Tests/TMDBSwiftTests/TVSeasonsMDBTests.swift
@@ -1,0 +1,79 @@
+//
+//  TVSeasonsMDBTests.swift
+//  
+//
+//  Created by Dylan Pearce on 5/27/22.
+//
+
+import XCTest
+@testable import TMDBSwift
+
+final class TVSeasonsMDBTests: XCTestCase {
+
+    let expecationTimeout: TimeInterval = 50
+
+    override func setUp() {
+        super.setUp()
+        TMDBConfig.apikey = "8a7a49369d1af6a70ec5a6787bbfcf79"
+    }
+
+    func testCredits() {
+        var data: TVCreditsMDB!
+        let expectation = self.expectation(description: "Wait for data to load.")
+
+        TVSeasonsMDB.credits(tvShowId: 1399, seasonNumber: 1, language: nil) { clientReturn, responseData in
+            data = responseData
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: expecationTimeout, handler: nil)
+        XCTAssertNotNil(data)
+    }
+
+    func testExternalIDS() {
+        var data: ExternalIdsMDB!
+        let expectation = self.expectation(description: "Wait for data to load.")
+
+        TVSeasonsMDB.externalIDS(tvShowId: 1399, seasonNumber: 1, language: nil) { clientReturn, responseData in
+            data = responseData
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: expecationTimeout, handler: nil)
+        XCTAssertNotNil(data)
+    }
+
+    func testImages() {
+        var data: ImagesMDB!
+        let expectation = self.expectation(description: "Wait for data to load.")
+
+        TVSeasonsMDB.images(tvShowId: 1399, seasonNumber: 1, language: nil) { clientReturn, responseData in
+            data = responseData
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: expecationTimeout, handler: nil)
+        XCTAssertNotNil(data.posters)
+    }
+
+    func testSeasonNumber() {
+        var data: TVSeasonsMDB!
+        let expectation = self.expectation(description: "Wait for data to load.")
+
+        TVSeasonsMDB.season_number(tvShowId: 1399, seasonNumber: 1, language: nil) { clientReturn, responseData in
+            data = responseData
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: expecationTimeout, handler: nil)
+        XCTAssertNotNil(data)
+    }
+
+    func testVideos() {
+        var data: [VideosMDB]!
+        let expectation = self.expectation(description: "Wait for data to load.")
+
+        TVSeasonsMDB.videos(tvShowId: 1399, seasonNumber: 1, language: nil) { clientReturn, responseData in
+            data = responseData
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: expecationTimeout, handler: nil)
+        XCTAssertNotNil(data)
+    }
+}

--- a/Tests/TMDBSwiftTests/TVSeasonsMDBTests.swift
+++ b/Tests/TMDBSwiftTests/TVSeasonsMDBTests.swift
@@ -21,7 +21,7 @@ final class TVSeasonsMDBTests: XCTestCase {
         var data: TVCreditsMDB!
         let expectation = self.expectation(description: "Wait for data to load.")
 
-        TVSeasonsMDB.credits(tvShowId: 1399, seasonNumber: 1, language: nil) { clientReturn, responseData in
+        TVSeasonsMDB.credits(tvShowId: 1399, seasonNumber: 1, language: nil) { _, responseData in
             data = responseData
             expectation.fulfill()
         }
@@ -33,7 +33,7 @@ final class TVSeasonsMDBTests: XCTestCase {
         var data: ExternalIdsMDB!
         let expectation = self.expectation(description: "Wait for data to load.")
 
-        TVSeasonsMDB.externalIDS(tvShowId: 1399, seasonNumber: 1, language: nil) { clientReturn, responseData in
+        TVSeasonsMDB.externalIDS(tvShowId: 1399, seasonNumber: 1, language: nil) { _, responseData in
             data = responseData
             expectation.fulfill()
         }
@@ -45,7 +45,7 @@ final class TVSeasonsMDBTests: XCTestCase {
         var data: ImagesMDB!
         let expectation = self.expectation(description: "Wait for data to load.")
 
-        TVSeasonsMDB.images(tvShowId: 1399, seasonNumber: 1, language: nil) { clientReturn, responseData in
+        TVSeasonsMDB.images(tvShowId: 1399, seasonNumber: 1, language: nil) { _, responseData in
             data = responseData
             expectation.fulfill()
         }
@@ -57,7 +57,7 @@ final class TVSeasonsMDBTests: XCTestCase {
         var data: TVSeasonsMDB!
         let expectation = self.expectation(description: "Wait for data to load.")
 
-        TVSeasonsMDB.season_number(tvShowId: 1399, seasonNumber: 1, language: nil) { clientReturn, responseData in
+        TVSeasonsMDB.season_number(tvShowId: 1399, seasonNumber: 1, language: nil) { _, responseData in
             data = responseData
             expectation.fulfill()
         }
@@ -69,7 +69,7 @@ final class TVSeasonsMDBTests: XCTestCase {
         var data: [VideosMDB]!
         let expectation = self.expectation(description: "Wait for data to load.")
 
-        TVSeasonsMDB.videos(tvShowId: 1399, seasonNumber: 1, language: nil) { clientReturn, responseData in
+        TVSeasonsMDB.videos(tvShowId: 1399, seasonNumber: 1, language: nil) { _, responseData in
             data = responseData
             expectation.fulfill()
         }


### PR DESCRIPTION
Adding tests for `TVSeasonsMDB`

- Update Decodable implementation for inherited classes
- Update `language` to be optional 