### PR TITLE
Update DocC workflow

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   Publish:
-    runs-on: ubuntu-latest
+    runs-on: macos-12
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Updating the DocC workflow to use the MacOS runner due to the lack of Await/async support on Linux.