### PR TITLE
Updating testability of new service classes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "TMDBSwift",
     platforms: [
-        .iOS(.v13),
+        .iOS(.v15),
         .tvOS(.v15),
         .macOS(.v12),
         .watchOS(.v8)

--- a/Sources/TMDBSwift/Client/Config.swift
+++ b/Sources/TMDBSwift/Client/Config.swift
@@ -8,9 +8,20 @@
 
 import Foundation
 
+/// A structure representing the API configuration for the current session.
 public struct TMDBConfig {
     /// API key to be used for queries.
-    public static var apikey: String!
+    public static var apikey: String?
+
+    /// The language provided to all network requests.
+    public static var language: String = "en-US"
+
     /// API base url.
-    public static var apiUrl = "https://api.themoviedb.org/3"
+    static var apiUrl = "https://api.themoviedb.org/3"
+
+    /// API scheme.
+    static let apiScheme = "https"
+
+    /// API host.
+    static let apiHost = "api.themoviedb.org/3"
 }

--- a/Sources/TMDBSwift/Client/Config.swift
+++ b/Sources/TMDBSwift/Client/Config.swift
@@ -23,5 +23,5 @@ public struct TMDBConfig {
     static let apiScheme = "https"
 
     /// API host.
-    static let apiHost = "api.themoviedb.org/3"
+    static let apiHost = "api.themoviedb.org"
 }

--- a/Sources/TMDBSwift/Models/Collection.swift
+++ b/Sources/TMDBSwift/Models/Collection.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// <#Description#>
-public struct Collection: Decodable {
+public struct Collection: Codable {
     /// <#Description#>
     public var id: Int
     /// <#Description#>

--- a/Sources/TMDBSwift/Models/Company.swift
+++ b/Sources/TMDBSwift/Models/Company.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// <#Description#>
-public struct Company: Decodable {
+public struct Company: Codable {
     /// <#Description#>
     public var id: Int
     /// <#Description#>

--- a/Sources/TMDBSwift/Models/Country.swift
+++ b/Sources/TMDBSwift/Models/Country.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// <#Description#>
-public struct Country: Decodable {
+public struct Country: Codable {
     /// <#Description#>
     public var countryCode: String // change to enum?
     /// <#Description#>

--- a/Sources/TMDBSwift/Models/ExternalIDType.swift
+++ b/Sources/TMDBSwift/Models/ExternalIDType.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum ExternalIDType {
+public enum ExternalIDType: Codable {
     case facebook(String)
     case twitter(String)
     case instagram(String)

--- a/Sources/TMDBSwift/Models/Genre.swift
+++ b/Sources/TMDBSwift/Models/Genre.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// <#Description#>
-public struct Genre: Decodable {
+public struct Genre: Codable {
     /// <#Description#>
     public var id: Int
     /// <#Description#>

--- a/Sources/TMDBSwift/Models/InternalResponses.swift
+++ b/Sources/TMDBSwift/Models/InternalResponses.swift
@@ -10,12 +10,12 @@ struct KeywordResponse: Decodable {
     var keywords: [Keyword] = []
 }
 
-struct AlternativeTitlesResponse: Decodable {
+struct AlternativeTitlesResponse: Codable {
     var id: Int
     var titles: [Title] = []
 }
 
-struct ExternalIDResponse: Decodable {
+struct ExternalIDResponse: Codable {
     var id: Int
     var imdb: String?
     var facebook: String?
@@ -28,6 +28,14 @@ struct ExternalIDResponse: Decodable {
         case facebook = "facebook_id"
         case instagram = "instagram_id"
         case twitter = "twitter_id"
+    }
+
+    init(id: Int, imdb: String?, facebook: String?, instagram: String?, twitter: String?) {
+        self.id = id
+        self.imdb = imdb
+        self.facebook = facebook
+        self.instagram = instagram
+        self.twitter = twitter
     }
 
     init(from decoder: Decoder) throws {

--- a/Sources/TMDBSwift/Models/Language.swift
+++ b/Sources/TMDBSwift/Models/Language.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// <#Description#>
-public struct Language: Decodable {
+public struct Language: Codable {
     /// <#Description#>
     public var languageCode: String // change to enum?
     /// <#Description#>

--- a/Sources/TMDBSwift/Models/Movie.swift
+++ b/Sources/TMDBSwift/Models/Movie.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// <#Description#>
-public struct Movie: Decodable {
+public struct Movie: Codable {
     /// <#Description#>
     public var id: Int
     /// <#Description#>
@@ -53,6 +53,10 @@ public struct Movie: Decodable {
     /// <#Description#>
     public var voteCount: Int?
 
+    public init(id: Int) {
+        self.id = id
+    }
+
     enum CodingKeys: String, CodingKey {
         case id
         case adult
@@ -79,6 +83,11 @@ public struct Movie: Decodable {
         case video
         case voteAverage = "vote_average"
         case voteCount = "vote_count"
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
     }
 
     public init(from decoder: Decoder) throws {

--- a/Sources/TMDBSwift/Models/Title.swift
+++ b/Sources/TMDBSwift/Models/Title.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 /// <#Description#>
-public struct Title: Decodable {
+public struct Title: Codable {
     /// <#Description#>
     public var countryCode: String // change to enum?
     /// <#Description#>
     public var title: String
     /// <#Description#>
-    public var type: String?
+    public var type: [String]?
 
     enum CodingKeys: String, CodingKey {
         case countryCode = "iso_3166_1"
@@ -15,10 +15,17 @@ public struct Title: Decodable {
         case type
     }
 
+    public init(countyCode: String, title: String, type: [String]?) {
+        self.countryCode = countyCode
+        self.title = title
+        self.type = type
+    }
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         countryCode = try container.decode(String.self, forKey: .countryCode)
         title = try container.decode(String.self, forKey: .title)
-        type = try? container.decode(String.self, forKey: .type)
+        let typeString = try? container.decode(String.self, forKey: .type)
+        type = typeString?.components(separatedBy: ", ")
     }
 }

--- a/Sources/TMDBSwift/Services/KeywordService.swift
+++ b/Sources/TMDBSwift/Services/KeywordService.swift
@@ -25,7 +25,7 @@ public final class KeywordService {
         var components = URLComponents()
         components.scheme = TMDBConfig.apiScheme
         components.host = TMDBConfig.apiHost
-        components.path = "/search/keyword"
+        components.path = "/3/search/keyword"
         components.queryItems = [
             URLQueryItem(name: "api_key", value: apiKey),
             URLQueryItem(name: "language", value: TMDBConfig.language),
@@ -50,7 +50,7 @@ public final class KeywordService {
         var components = URLComponents()
         components.scheme = TMDBConfig.apiScheme
         components.host = TMDBConfig.apiHost
-        components.path = "/movie/\(movieID)/keywords"
+        components.path = "/3/movie/\(movieID)/keywords"
         components.queryItems = [
             URLQueryItem(name: "api_key", value: apiKey),
             URLQueryItem(name: "language", value: TMDBConfig.language),
@@ -73,7 +73,7 @@ public final class KeywordService {
         var components = URLComponents()
         components.scheme = TMDBConfig.apiScheme
         components.host = TMDBConfig.apiHost
-        components.path = "/tv/\(tvID)/keywords"
+        components.path = "/3/tv/\(tvID)/keywords"
         components.queryItems = [
             URLQueryItem(name: "api_key", value: apiKey),
             URLQueryItem(name: "language", value: TMDBConfig.language),
@@ -96,7 +96,7 @@ public final class KeywordService {
         var components = URLComponents()
         components.scheme = TMDBConfig.apiScheme
         components.host = TMDBConfig.apiHost
-        components.path = "/discover/tv"
+        components.path = "/3/discover/tv"
         components.queryItems = [
             URLQueryItem(name: "api_key", value: apiKey),
             URLQueryItem(name: "language", value: TMDBConfig.language),
@@ -121,7 +121,7 @@ public final class KeywordService {
         var components = URLComponents()
         components.scheme = TMDBConfig.apiScheme
         components.host = TMDBConfig.apiHost
-        components.path = "/discover/movie"
+        components.path = "/3/discover/movie"
         components.queryItems = [
             URLQueryItem(name: "api_key", value: apiKey),
             URLQueryItem(name: "language", value: TMDBConfig.language),
@@ -146,7 +146,7 @@ public final class KeywordService {
         var components = URLComponents()
         components.scheme = TMDBConfig.apiScheme
         components.host = TMDBConfig.apiHost
-        components.path = "/keyword/\(keywordID)"
+        components.path = "/3/keyword/\(keywordID)"
         components.queryItems = [
             URLQueryItem(name: "api_key", value: apiKey),
             URLQueryItem(name: "language", value: TMDBConfig.language),

--- a/Sources/TMDBSwift/Services/KeywordService.swift
+++ b/Sources/TMDBSwift/Services/KeywordService.swift
@@ -1,24 +1,39 @@
 import Foundation
 
-/// <#Description#>
 public final class KeywordService {
 
-    /// <#Description#>
+    /// The shared keyword service. Use to instantiate one instance of KeywordService for use throughout your application. If finer-grained optimizations are desired, create separate instances. See the init documentation for more details.
     static let shared: KeywordService = KeywordService()
 
-    // get keywords for string
+    var urlSession: URLSessionProtocol
 
-    /// <#Description#>
-    /// - Parameter query: <#query description#>
-    /// - Parameter page: <#page description#>
-    /// - Returns: <#description#>
+    init(urlSession: URLSessionProtocol) {
+        self.urlSession = urlSession
+    }
+
+    /// Initializes the keyword service. Use for creating different KeywordService instances for optimizations. For instance, may be used to separate out high-priority requests and low-priority requests for performance. If one instance of KeywordService is preferred, see the shared documentation.
+    public convenience init() {
+        self.init(urlSession: URLSession.shared)
+    }
+
+    // MARK: - Get Keywords
+
     public final func keywords(for query: String, page: Int = 1) async throws -> PagedResults<[Keyword]> {
 
         guard let apiKey = TMDBConfig.apikey else { throw TMDBError.invalidAPIKey }
 
-        guard let url = URL(string: "\(TMDBConfig.apiUrl)/search/keyword?api_key=\(apiKey)&query=\(query)&page=\(page)") else {
-            throw TMDBError.invalidURL
-        }
+        var components = URLComponents()
+        components.scheme = TMDBConfig.apiScheme
+        components.host = TMDBConfig.apiHost
+        components.path = "/search/keyword"
+        components.queryItems = [
+            URLQueryItem(name: "api_key", value: apiKey),
+            URLQueryItem(name: "language", value: TMDBConfig.language),
+            URLQueryItem(name: "query", value: query),
+            URLQueryItem(name: "page", value: "\(page)"),
+        ]
+
+        guard let url = components.url else { throw TMDBError.invalidURL }
 
         let (data, _) = try await URLSession.shared.data(from: url)
 
@@ -26,15 +41,22 @@ public final class KeywordService {
         return result
     }
 
-    // get keywords for movie
+    // MARK: - Get Keywords for Movie
 
     public final func keywords(movieID: Int) async throws -> [Keyword] {
 
         guard let apiKey = TMDBConfig.apikey else { throw TMDBError.invalidAPIKey }
 
-        guard let url = URL(string: "\(TMDBConfig.apiUrl)/movie/\(movieID)/keywords?api_key=\(apiKey)") else {
-            throw TMDBError.invalidURL
-        }
+        var components = URLComponents()
+        components.scheme = TMDBConfig.apiScheme
+        components.host = TMDBConfig.apiHost
+        components.path = "/movie/\(movieID)/keywords"
+        components.queryItems = [
+            URLQueryItem(name: "api_key", value: apiKey),
+            URLQueryItem(name: "language", value: TMDBConfig.language),
+        ]
+
+        guard let url = components.url else { throw TMDBError.invalidURL }
 
         let (data, _) = try await URLSession.shared.data(from: url)
 
@@ -42,15 +64,22 @@ public final class KeywordService {
         return result.keywords
     }
 
-    // get keywords for tv
+    // MARK: - Get Keywords for TV
 
     public final func keywords(tvID: Int) async throws -> [Keyword] {
 
         guard let apiKey = TMDBConfig.apikey else { throw TMDBError.invalidAPIKey }
 
-        guard let url = URL(string: "\(TMDBConfig.apiUrl)/tv/\(tvID)/keywords?api_key=\(apiKey)") else {
-            throw TMDBError.invalidURL
-        }
+        var components = URLComponents()
+        components.scheme = TMDBConfig.apiScheme
+        components.host = TMDBConfig.apiHost
+        components.path = "/tv/\(tvID)/keywords"
+        components.queryItems = [
+            URLQueryItem(name: "api_key", value: apiKey),
+            URLQueryItem(name: "language", value: TMDBConfig.language),
+        ]
+
+        guard let url = components.url else { throw TMDBError.invalidURL }
 
         let (data, _) = try await URLSession.shared.data(from: url)
 
@@ -58,30 +87,49 @@ public final class KeywordService {
         return result.results
     }
 
-    // get tv for keywords
+    // MARK: - Get TV Series for Keywords
 
     public final func tvSeries(keywords: [String], page: Int = 1) async throws -> PagedResults<[TVSeries]> {
 
         guard let apiKey = TMDBConfig.apikey else { throw TMDBError.invalidAPIKey }
 
-        guard let url = URL(string: "\(TMDBConfig.apiUrl)/discover/tv?with_keywords=\(keywords.joined(separator: ","))&api_key=\(apiKey)&page=\(page)") else {
-            throw TMDBError.invalidURL
-        }
+        var components = URLComponents()
+        components.scheme = TMDBConfig.apiScheme
+        components.host = TMDBConfig.apiHost
+        components.path = "/discover/tv"
+        components.queryItems = [
+            URLQueryItem(name: "api_key", value: apiKey),
+            URLQueryItem(name: "language", value: TMDBConfig.language),
+            URLQueryItem(name: "with_keywords", value: keywords.joined(separator: ",")),
+            URLQueryItem(name: "page", value: "\(page)"),
+        ]
+
+        guard let url = components.url else { throw TMDBError.invalidURL }
 
         let (data, _) = try await URLSession.shared.data(from: url)
 
         let result = try JSONDecoder().decode(PagedResults<[TVSeries]>.self, from: data)
         return result
     }
-    // get movie for keywords
+
+    // MARK: - Get Movies for Keywords
 
     public final func movies(keywords: [String], page: Int = 1) async throws -> PagedResults<[Movie]> {
 
         guard let apiKey = TMDBConfig.apikey else { throw TMDBError.invalidAPIKey }
 
-        guard let url = URL(string: "\(TMDBConfig.apiUrl)/discover/movie?with_keywords=\(keywords.joined(separator: ","))&api_key=\(apiKey)&page=\(page)") else {
-            throw TMDBError.invalidURL
-        }
+        var components = URLComponents()
+        components.scheme = TMDBConfig.apiScheme
+        components.host = TMDBConfig.apiHost
+        components.path = "/discover/movie"
+        components.queryItems = [
+            URLQueryItem(name: "api_key", value: apiKey),
+            URLQueryItem(name: "language", value: TMDBConfig.language),
+            URLQueryItem(name: "with_keywords", value: keywords.joined(separator: ",")),
+            URLQueryItem(name: "page", value: "\(page)"),
+        ]
+
+        guard let url = components.url else { throw TMDBError.invalidURL }
 
         let (data, _) = try await URLSession.shared.data(from: url)
 
@@ -89,15 +137,22 @@ public final class KeywordService {
         return result
     }
 
-    // get detail for keyword id
+    // MARK: - Get Keywords for Keyword IDs
 
     public final func keyword(for keywordID: Int) async throws -> Keyword {
 
         guard let apiKey = TMDBConfig.apikey else { throw TMDBError.invalidAPIKey }
 
-        guard let url = URL(string: "\(TMDBConfig.apiUrl)/keyword/\(keywordID)?api_key=\(apiKey)") else {
-            throw TMDBError.invalidURL
-        }
+        var components = URLComponents()
+        components.scheme = TMDBConfig.apiScheme
+        components.host = TMDBConfig.apiHost
+        components.path = "/keyword/\(keywordID)"
+        components.queryItems = [
+            URLQueryItem(name: "api_key", value: apiKey),
+            URLQueryItem(name: "language", value: TMDBConfig.language),
+        ]
+
+        guard let url = components.url else { throw TMDBError.invalidURL }
 
         let (data, _) = try await URLSession.shared.data(from: url)
 

--- a/Sources/TMDBSwift/Services/MovieService.swift
+++ b/Sources/TMDBSwift/Services/MovieService.swift
@@ -29,7 +29,7 @@ public final class MovieService {
         var components = URLComponents()
         components.scheme = TMDBConfig.apiScheme
         components.host = TMDBConfig.apiHost
-        components.path = "/movie/\(id)"
+        components.path = "/3/movie/\(id)"
         components.queryItems = [
             URLQueryItem(name: "api_key", value: apiKey),
             URLQueryItem(name: "language", value: TMDBConfig.language),
@@ -79,7 +79,7 @@ public final class MovieService {
         var components = URLComponents()
         components.scheme = TMDBConfig.apiScheme
         components.host = TMDBConfig.apiHost
-        components.path = "/movie/\(id)/alternative_titles"
+        components.path = "/3/movie/\(id)/alternative_titles"
         components.queryItems = [
             URLQueryItem(name: "api_key", value: apiKey),
             URLQueryItem(name: "language", value: TMDBConfig.language),
@@ -133,7 +133,7 @@ public final class MovieService {
         var components = URLComponents()
         components.scheme = TMDBConfig.apiScheme
         components.host = TMDBConfig.apiHost
-        components.path = "/movie/\(id)/external_ids"
+        components.path = "/3/movie/\(id)/external_ids"
         components.queryItems = [
             URLQueryItem(name: "api_key", value: apiKey),
             URLQueryItem(name: "language", value: TMDBConfig.language),

--- a/Sources/TMDBSwift/Services/MovieService.swift
+++ b/Sources/TMDBSwift/Services/MovieService.swift
@@ -28,9 +28,13 @@ public final class MovieService {
 
         var components = URLComponents()
         components.scheme = TMDBConfig.apiScheme
+        components.host = TMDBConfig.apiHost
+        components.path = "/movie/\(id)"
+        components.queryItems = [
             URLQueryItem(name: "api_key", value: apiKey),
+            URLQueryItem(name: "language", value: TMDBConfig.language),
+        ]
 
-        let (data, _) = try await URLSession.shared.data(from: url)
         guard let url = components.url else { throw TMDBError.invalidURL }
 
         let (data, _) = try await urlSession.data(from: url)

--- a/Sources/TMDBSwift/Services/MovieService.swift
+++ b/Sources/TMDBSwift/Services/MovieService.swift
@@ -1,32 +1,57 @@
 import Foundation
 
-/// <#Description#>
+/// ``MovieService`` is the collection of movie centered endpoints containing methods that require a movie ID.
 public final class MovieService {
 
-    /// <#Description#>
-    static let shared: MovieService = MovieService()
+    /// The shared movie service. Use to instantiate one instance of MovieService for use throughout your application. If finer-grained optimizations are desired, create separate instances. See the init documentation for more details.
+    public static let shared: MovieService = MovieService()
 
-    /// <#Description#>
-    /// - Parameter id: <#id description#>
-    /// - Returns: <#description#>
+    var urlSession: URLSessionProtocol
+
+    init(urlSession: URLSessionProtocol) {
+        self.urlSession = urlSession
+    }
+
+    /// Initializes the movie service. Use for creating different MovieService instances for optimizations. For instance, may be used to separate out high-priority requests and low-priority requests for performance. If one instance of MovieService is preferred, see the shared documentation.
+    public convenience init() {
+        self.init(urlSession: URLSession.shared)
+    }
+
+    // MARK: - Get Details
+
+    /// Get the primary information about a movie.
+    /// - Parameter id: A movies ID.
+    /// - Returns: Returns a ``Movie`` the details for the requested movie ID.
     public final func details(for id: Int) async throws -> Movie {
 
         guard let apiKey = TMDBConfig.apikey else { throw TMDBError.invalidAPIKey }
 
-        guard let url = URL(string: "\(TMDBConfig.apiUrl)/movie/\(id)?api_key=\(apiKey)") else {
-            throw TMDBError.invalidURL
-        }
+        var components = URLComponents()
+        components.scheme = TMDBConfig.apiScheme
+            URLQueryItem(name: "api_key", value: apiKey),
 
         let (data, _) = try await URLSession.shared.data(from: url)
+        guard let url = components.url else { throw TMDBError.invalidURL }
+
+        let (data, _) = try await urlSession.data(from: url)
 
         let movieDetailsResult = try JSONDecoder().decode(Movie.self, from: data)
         return movieDetailsResult
     }
 
-    /// <#Description#>
+    /// Get the primary information about a movie.
+    ///
+    /// **Important**
+    ///
+    ///  You can call this method from synchronous code using a completion handler, as shown on this page, or you can call it as an asynchronous method that has the following declaration:
+    ///  ```
+    ///  func details(for id: Int) async throws -> Movie
+    ///  ```
+    ///
     /// - Parameters:
-    ///   - id: <#id description#>
-    ///   - completion: <#completion description#>
+    ///   - id: A movies ID.
+    ///   - completion:  A closure to be invoked asynchronously after MovieService fetches data. The closure takes one parameter:
+    ///   - movie: The fetched ``Movie``, or `nil` if none was found.
     public final func fetchDetails(for id: Int, completion: @escaping (Movie?) -> Void) {
         Task {
             do {
@@ -38,27 +63,49 @@ public final class MovieService {
         }
     }
 
-    /// <#Description#>
-    /// - Parameter id: <#id description#>
-    /// - Returns: <#description#>
-    public final func alternativeTitles(for id: Int) async throws -> [Title] {
+    // MARK: - Get Alternative Titles
+
+    /// Get the alternative titles for a movie.
+    /// - Parameter id: A movies ID.
+    /// - Returns: Returns an array of alternative titles for the requested movie ID
+    public final func alternativeTitles(for id: Int, country: String? = nil) async throws -> [Title] {
 
         guard let apiKey = TMDBConfig.apikey else { throw TMDBError.invalidAPIKey }
 
-        guard let url = URL(string: "\(TMDBConfig.apiUrl)/movie/\(id)/alternative_titles?api_key=\(apiKey)") else {
-            throw TMDBError.invalidURL
+        var components = URLComponents()
+        components.scheme = TMDBConfig.apiScheme
+        components.host = TMDBConfig.apiHost
+        components.path = "/movie/\(id)/alternative_titles"
+        components.queryItems = [
+            URLQueryItem(name: "api_key", value: apiKey),
+            URLQueryItem(name: "language", value: TMDBConfig.language),
+        ]
+
+        if let country = country {
+            components.queryItems?.append(URLQueryItem(name: "country", value: country))
         }
 
-        let (data, _) = try await URLSession.shared.data(from: url)
+        guard let url = components.url else { throw TMDBError.invalidURL }
+
+        let (data, _) = try await urlSession.data(from: url)
 
         let alternativeTitlesResponse = try JSONDecoder().decode(AlternativeTitlesResponse.self, from: data)
         return alternativeTitlesResponse.titles
     }
 
-    /// <#Description#>
+    /// Get the alternative titles for a movie.
+    ///
+    /// **Important**
+    ///
+    ///  You can call this method from synchronous code using a completion handler, as shown on this page, or you can call it as an asynchronous method that has the following declaration:
+    ///  ```
+    ///  func alternativeTitles(for id: Int, country: String? = nil) async throws -> [Title]
+    ///  ```
+    ///
     /// - Parameters:
-    ///   - id: <#id description#>
-    ///   - completion: <#completion description#>
+    ///   - id: A movies ID.
+    ///   - completion:  A closure to be invoked asynchronously after ``MovieService`` fetches data. The closure takes one parameter:
+    ///   - titles: The fetched array of ``Title``, or `nil` if none was found.
     public final func fetchAlternativeTitles(for id: Int, completion: @escaping ([Title]?) -> Void) {
         Task {
             do {
@@ -70,18 +117,27 @@ public final class MovieService {
         }
     }
 
-    /// <#Description#>
-    /// - Parameter id: <#id description#>
-    /// - Returns: <#description#>
+    // MARK: - Get External IDs
+
+    /// Get the external ids for a movie.
+    /// - Parameter id: A movies ID.
+    /// - Returns: Returns an array of ``ExternalIDType`` for the requested movie ID.
     public final func externalIDs(for id: Int) async throws -> [ExternalIDType] {
 
         guard let apiKey = TMDBConfig.apikey else { throw TMDBError.invalidAPIKey }
 
-        guard let url = URL(string: "\(TMDBConfig.apiUrl)/movie/\(id)/external_ids?api_key=\(apiKey)") else {
-            throw TMDBError.invalidURL
-        }
+        var components = URLComponents()
+        components.scheme = TMDBConfig.apiScheme
+        components.host = TMDBConfig.apiHost
+        components.path = "/movie/\(id)/external_ids"
+        components.queryItems = [
+            URLQueryItem(name: "api_key", value: apiKey),
+            URLQueryItem(name: "language", value: TMDBConfig.language),
+        ]
 
-        let (data, _) = try await URLSession.shared.data(from: url)
+        guard let url = components.url else { throw TMDBError.invalidURL }
+
+        let (data, _) = try await urlSession.data(from: url)
 
         let externalIDResponse = try JSONDecoder().decode(ExternalIDResponse.self, from: data)
 
@@ -106,10 +162,19 @@ public final class MovieService {
         return externalIDArray
     }
 
-    /// <#Description#>
+    /// Get the external ids for a movie.
+    ///
+    /// **Important**
+    ///
+    ///  You can call this method from synchronous code using a completion handler, as shown on this page, or you can call it as an asynchronous method that has the following declaration:
+    ///  ```
+    ///  func externalIDs(for id: Int) async throws -> [ExternalIDType]
+    ///  ```
+    ///
     /// - Parameters:
-    ///   - id: <#id description#>
-    ///   - completion: <#completion description#>
+    ///   - id: A movies ID.
+    ///   - completion:  A closure to be invoked asynchronously after ``MovieService`` fetches data. The closure takes one parameter:
+    ///   - titles: The fetched array of ``ExternalIDType``, or `nil` if none was found.
     public final func fetchExternalIDs(for id: Int, completion: @escaping ([ExternalIDType]?) -> Void) {
         Task {
             do {
@@ -120,5 +185,4 @@ public final class MovieService {
             }
         }
     }
-
 }

--- a/Sources/TMDBSwift/Services/URLSessionProtocol.swift
+++ b/Sources/TMDBSwift/Services/URLSessionProtocol.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+protocol URLSessionProtocol {
+    func data(
+        from url: URL,
+        delegate: URLSessionTaskDelegate?
+    ) async throws -> (Data, URLResponse)
+}
+
+extension URLSessionProtocol {
+    func data(from url: URL) async throws -> (Data, URLResponse) {
+        try await data(from: url, delegate: nil)
+    }
+}
+
+extension URLSession: URLSessionProtocol { }

--- a/Tests/TMDBSwiftTests/Helpers/MockURLSession.swift
+++ b/Tests/TMDBSwiftTests/Helpers/MockURLSession.swift
@@ -1,0 +1,10 @@
+import Foundation
+@testable import TMDBSwift
+
+final class MockURLSession: URLSessionProtocol {
+    var result = Result<Data, Error>.success(Data())
+
+    func data(from url: URL, delegate: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
+        try (result.get(), URLResponse())
+    }
+}

--- a/Tests/TMDBSwiftTests/Models/MockAlternativeTitlesResponse.swift
+++ b/Tests/TMDBSwiftTests/Models/MockAlternativeTitlesResponse.swift
@@ -1,0 +1,5 @@
+@testable import TMDBSwift
+
+extension AlternativeTitlesResponse {
+    static let mock = AlternativeTitlesResponse(id: 1, titles: [Title.mock, Title.mock])
+}

--- a/Tests/TMDBSwiftTests/Models/MockExternalIDResponse.swift
+++ b/Tests/TMDBSwiftTests/Models/MockExternalIDResponse.swift
@@ -1,0 +1,5 @@
+@testable import TMDBSwift
+
+extension ExternalIDResponse {
+    static let mock = ExternalIDResponse(id: 1, imdb: "12345", facebook: "12345", instagram: "12345", twitter: "12345")
+}

--- a/Tests/TMDBSwiftTests/Models/MockMovie.swift
+++ b/Tests/TMDBSwiftTests/Models/MockMovie.swift
@@ -1,0 +1,5 @@
+@testable import TMDBSwift
+
+extension Movie {
+    static let mock = Movie(id: 11)
+}

--- a/Tests/TMDBSwiftTests/Models/MockTitle.swift
+++ b/Tests/TMDBSwiftTests/Models/MockTitle.swift
@@ -1,0 +1,5 @@
+@testable import TMDBSwift
+
+extension Title {
+    static let mock = Title(countyCode: "en-US", title: "Some Title", type: nil)
+}

--- a/Tests/TMDBSwiftTests/Services/MovieServiceTests.swift
+++ b/Tests/TMDBSwiftTests/Services/MovieServiceTests.swift
@@ -4,19 +4,49 @@ import XCTest
 final class MovieServiceTests: XCTestCase {
     override func setUp() {
         super.setUp()
-        TMDBConfig.apikey = "8a7a49369d1af6a70ec5a6787bbfcf79"
+        TMDBConfig.apikey = "0"
     }
 
+    func testInit() {
+        let movieService = MovieService()
+
+        let actualURLSession = movieService.urlSession
+
+        XCTAssertNotNil(actualURLSession as? URLSession)
+    }
+
+    // MARK: - Get Details
+
     func testDetails() async throws {
-        let data = try await MovieService.shared.details(for: 11)
+        let urlSession = MockURLSession()
+        urlSession.result = try .success(JSONEncoder().encode(Movie.mock))
+        
+        let data = try? await MovieService(urlSession: urlSession).details(for: 11)
         XCTAssertNotNil(data)
     }
 
-    func testFetchDetails() {
+    func testDetails_InvalidAPIKey() async throws {
+        let urlSession = MockURLSession()
+        urlSession.result = .failure(NSError())
+
+        TMDBConfig.apikey = nil
+
+        do {
+            let _ = try await MovieService(urlSession: urlSession).details(for: 11)
+            XCTFail("Function should have thrown by now")
+        } catch let error as TMDBError {
+            XCTAssertEqual(error, TMDBError.invalidAPIKey)
+        }
+    }
+
+    func testFetchDetails_Success() {
         var data: Movie?
+        let urlSession = MockURLSession()
+        urlSession.result = try! .success(JSONEncoder().encode(Movie.mock))
+
         let expectation = self.expectation(description: "Wait for data to load.")
 
-        MovieService.shared.fetchDetails(for: 11) { movie in
+        MovieService(urlSession: urlSession).fetchDetails(for: 11) { movie in
             data = movie
             expectation.fulfill()
         }
@@ -24,16 +54,53 @@ final class MovieServiceTests: XCTestCase {
         XCTAssertNotNil(data)
     }
 
+    func testFetchDetails_Failure() {
+        var data: Movie? = Movie.mock
+        let urlSession = MockURLSession()
+        urlSession.result = .failure(NSError())
+
+        let expectation = self.expectation(description: "Wait for data to load.")
+
+        MovieService(urlSession: urlSession).fetchDetails(for: 11) { movie in
+            data = movie
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: expecationTimeout, handler: nil)
+        XCTAssertNil(data)
+    }
+
+    // MARK: - Get Alternative Titles
+
     func testAlternativeTitles() async throws {
-        let data = try await MovieService.shared.alternativeTitles(for: 11)
+        let urlSession = MockURLSession()
+        urlSession.result = try .success(JSONEncoder().encode(AlternativeTitlesResponse.mock))
+
+        let data = try await MovieService(urlSession: urlSession).alternativeTitles(for: 11, country: "anything")
         XCTAssertNotNil(data)
     }
 
-    func testFetchAlternativeTitles() {
+    func testAlternativeTitles_InvalidAPIKey() async throws {
+        let urlSession = MockURLSession()
+        urlSession.result = .failure(NSError())
+
+        TMDBConfig.apikey = nil
+
+        do {
+            let _ = try await MovieService(urlSession: urlSession).alternativeTitles(for: 11)
+            XCTFail("Function should have thrown by now")
+        } catch let error as TMDBError {
+            XCTAssertEqual(error, TMDBError.invalidAPIKey)
+        }
+    }
+
+    func testFetchAlternativeTitles_Success() {
         var data: [Title]?
+        let urlSession = MockURLSession()
+        urlSession.result = try! .success(JSONEncoder().encode(AlternativeTitlesResponse.mock))
+
         let expectation = self.expectation(description: "Wait for data to load.")
 
-        MovieService.shared.fetchAlternativeTitles(for: 11) { titles in
+        MovieService(urlSession: urlSession).fetchAlternativeTitles(for: 11) { titles in
             data = titles
             expectation.fulfill()
         }
@@ -41,20 +108,72 @@ final class MovieServiceTests: XCTestCase {
         XCTAssertNotNil(data)
     }
 
+    func testFetchAlternativeTitles_Failure() {
+        var data: [Title]? = [Title.mock]
+        let urlSession = MockURLSession()
+        urlSession.result = .failure(NSError())
+
+        let expectation = self.expectation(description: "Wait for data to load.")
+
+        MovieService(urlSession: urlSession).fetchAlternativeTitles(for: 11) { titles in
+            data = titles
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: expecationTimeout, handler: nil)
+        XCTAssertNil(data)
+    }
+
+    // MARK: - Get External IDs
+
     func testExternalIDs() async throws {
-        let data = try await MovieService.shared.externalIDs(for: 11)
+        let urlSession = MockURLSession()
+        urlSession.result = try .success(JSONEncoder().encode(ExternalIDResponse.mock))
+
+        let data = try await MovieService(urlSession: urlSession).externalIDs(for: 11)
         XCTAssertFalse(data.isEmpty)
     }
 
-    func testFetchExternalIDs() {
+    func testExternalIDs_InvalidAPIKey() async throws {
+        let urlSession = MockURLSession()
+        urlSession.result = .failure(NSError())
+
+        TMDBConfig.apikey = nil
+
+        do {
+            let _ = try await MovieService(urlSession: urlSession).externalIDs(for: 11)
+            XCTFail("Function should have thrown by now")
+        } catch let error as TMDBError {
+            XCTAssertEqual(error, TMDBError.invalidAPIKey)
+        }
+    }
+
+    func testFetchExternalIDs_Success() {
         var data: [ExternalIDType]?
+        let urlSession = MockURLSession()
+        urlSession.result = try! .success(JSONEncoder().encode(ExternalIDResponse(id: 1, imdb: nil, facebook: nil, instagram: nil, twitter: "12345")))
+
         let expectation = self.expectation(description: "Wait for data to load.")
 
-        MovieService.shared.fetchExternalIDs(for: 11) { types in
+        MovieService(urlSession: urlSession).fetchExternalIDs(for: 11) { types in
             data = types
             expectation.fulfill()
         }
         waitForExpectations(timeout: expecationTimeout, handler: nil)
         XCTAssertNotNil(data)
+    }
+
+    func testFetchExternalIDs_Failure() {
+        var data: [ExternalIDType]? = [.imdb("123")]
+        let urlSession = MockURLSession()
+        urlSession.result = .failure(NSError())
+
+        let expectation = self.expectation(description: "Wait for data to load.")
+
+        MovieService(urlSession: urlSession).fetchExternalIDs(for: 11) { types in
+            data = types
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: expecationTimeout, handler: nil)
+        XCTAssertNil(data)
     }
 }

--- a/Tests/TMDBSwiftTests/Services/MovieServiceTests.swift
+++ b/Tests/TMDBSwiftTests/Services/MovieServiceTests.swift
@@ -39,10 +39,10 @@ final class MovieServiceTests: XCTestCase {
         }
     }
 
-    func testFetchDetails_Success() {
+    func testFetchDetails_Success() throws {
         var data: Movie?
         let urlSession = MockURLSession()
-        urlSession.result = try! .success(JSONEncoder().encode(Movie.mock))
+        urlSession.result = try .success(JSONEncoder().encode(Movie.mock))
 
         let expectation = self.expectation(description: "Wait for data to load.")
 
@@ -93,10 +93,10 @@ final class MovieServiceTests: XCTestCase {
         }
     }
 
-    func testFetchAlternativeTitles_Success() {
+    func testFetchAlternativeTitles_Success() throws {
         var data: [Title]?
         let urlSession = MockURLSession()
-        urlSession.result = try! .success(JSONEncoder().encode(AlternativeTitlesResponse.mock))
+        urlSession.result = try .success(JSONEncoder().encode(AlternativeTitlesResponse.mock))
 
         let expectation = self.expectation(description: "Wait for data to load.")
 
@@ -147,10 +147,10 @@ final class MovieServiceTests: XCTestCase {
         }
     }
 
-    func testFetchExternalIDs_Success() {
+    func testFetchExternalIDs_Success() throws {
         var data: [ExternalIDType]?
         let urlSession = MockURLSession()
-        urlSession.result = try! .success(JSONEncoder().encode(ExternalIDResponse(id: 1, imdb: nil, facebook: nil, instagram: nil, twitter: "12345")))
+        urlSession.result = try .success(JSONEncoder().encode(ExternalIDResponse(id: 1, imdb: nil, facebook: nil, instagram: nil, twitter: "12345")))
 
         let expectation = self.expectation(description: "Wait for data to load.")
 

--- a/Tests/TMDBSwiftTests/Services/MovieServiceTests.swift
+++ b/Tests/TMDBSwiftTests/Services/MovieServiceTests.swift
@@ -20,7 +20,7 @@ final class MovieServiceTests: XCTestCase {
     func testDetails() async throws {
         let urlSession = MockURLSession()
         urlSession.result = try .success(JSONEncoder().encode(Movie.mock))
-        
+
         let data = try? await MovieService(urlSession: urlSession).details(for: 11)
         XCTAssertNotNil(data)
     }
@@ -32,7 +32,7 @@ final class MovieServiceTests: XCTestCase {
         TMDBConfig.apikey = nil
 
         do {
-            let _ = try await MovieService(urlSession: urlSession).details(for: 11)
+            _ = try await MovieService(urlSession: urlSession).details(for: 11)
             XCTFail("Function should have thrown by now")
         } catch let error as TMDBError {
             XCTAssertEqual(error, TMDBError.invalidAPIKey)
@@ -86,7 +86,7 @@ final class MovieServiceTests: XCTestCase {
         TMDBConfig.apikey = nil
 
         do {
-            let _ = try await MovieService(urlSession: urlSession).alternativeTitles(for: 11)
+            _ = try await MovieService(urlSession: urlSession).alternativeTitles(for: 11)
             XCTFail("Function should have thrown by now")
         } catch let error as TMDBError {
             XCTAssertEqual(error, TMDBError.invalidAPIKey)
@@ -140,7 +140,7 @@ final class MovieServiceTests: XCTestCase {
         TMDBConfig.apikey = nil
 
         do {
-            let _ = try await MovieService(urlSession: urlSession).externalIDs(for: 11)
+            _ = try await MovieService(urlSession: urlSession).externalIDs(for: 11)
             XCTFail("Function should have thrown by now")
         } catch let error as TMDBError {
             XCTAssertEqual(error, TMDBError.invalidAPIKey)


### PR DESCRIPTION
- Added the URLSessionProtocol
    - Allows for mocking of URLSession
- Updated MovieService documentation
- Updated MovieService and Keyword Service URL building
- Bumped iOS version to iOS 15 (closes #72)
- Updated MovieServiceTests to not actually call any web request
    - Plan is for a separate integration test suite to run on pushes to master and maybe weekly to ensure nothing is broken

More work to do on `Movie` testability, including testing specifically encoding and decoding from sample endpoint responses.