### PR TITLE
Decoders and folder documentation

### DIFF
--- a/Sources/TMDBSwift/Models/Collection.swift
+++ b/Sources/TMDBSwift/Models/Collection.swift
@@ -17,12 +17,4 @@ public struct Collection: Codable {
         case posterPath = "poster_path"
         case backdropPath = "backdrop_path"
     }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        id = try container.decode(Int.self, forKey: .id)
-        name = try container.decode(String.self, forKey: .name)
-        posterPath = try? container.decode(String.self, forKey: .posterPath)
-        backdropPath = try? container.decode(String.self, forKey: .backdropPath)
-    }
 }

--- a/Sources/TMDBSwift/Models/Company.swift
+++ b/Sources/TMDBSwift/Models/Company.swift
@@ -17,12 +17,4 @@ public struct Company: Codable {
         case name
         case originCountry = "origin_country"
     }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        id = try container.decode(Int.self, forKey: .id)
-        logoPath = try? container.decode(String.self, forKey: .logoPath)
-        name = try? container.decode(String.self, forKey: .name)
-        originCountry = try? container.decode(String.self, forKey: .originCountry)
-    }
 }

--- a/Sources/TMDBSwift/Models/Country.swift
+++ b/Sources/TMDBSwift/Models/Country.swift
@@ -11,10 +11,4 @@ public struct Country: Codable {
         case countryCode = "iso_3166_1"
         case name
     }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        countryCode = try container.decode(String.self, forKey: .countryCode)
-        name = try container.decode(String.self, forKey: .name)
-    }
 }

--- a/Sources/TMDBSwift/Models/InternalResponses.swift
+++ b/Sources/TMDBSwift/Models/InternalResponses.swift
@@ -37,13 +37,4 @@ struct ExternalIDResponse: Codable {
         self.instagram = instagram
         self.twitter = twitter
     }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        id = try container.decode(Int.self, forKey: .id)
-        imdb = try? container.decode(String.self, forKey: .imdb)
-        facebook = try? container.decode(String.self, forKey: .facebook)
-        instagram = try? container.decode(String.self, forKey: .instagram)
-        twitter = try? container.decode(String.self, forKey: .twitter)
-    }
 }

--- a/Sources/TMDBSwift/Models/Language.swift
+++ b/Sources/TMDBSwift/Models/Language.swift
@@ -11,10 +11,4 @@ public struct Language: Codable {
         case languageCode = "iso_639_1"
         case name
     }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        languageCode = try container.decode(String.self, forKey: .languageCode)
-        name = try container.decode(String.self, forKey: .name)
-    }
 }

--- a/docs/Package.swift
+++ b/docs/Package.swift
@@ -1,0 +1,11 @@
+// swift-tools-version:5.6
+
+// This is here so Xcode won't include the `docs` folder
+
+import PackageDescription
+
+let package = Package(
+  name: "docs",
+  products: [],
+  targets: []
+)


### PR DESCRIPTION
- Remove decodable inits as they are unneeded.
- Add Package.swift file so Xcode ignores the docs folder.