### PR TITLE
Update CI to run against iOS, MacOS, TVOS, watchOS

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,12 +5,97 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.ref_name }}
+  cancel-in-progress: true
 jobs:
-  test:
-    runs-on: macos-12
-    timeout-minutes: 30
+  macOS:
+    name: Test macOS, All Xcodes and Swifts
+    runs-on: ${{ matrix.runsOn }}
+    env:
+      DEVELOPER_DIR: "/Applications/${{ matrix.xcode }}/Contents/Developer"
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - xcode: "Xcode_13.4.1.app"
+            runsOn: macOS-12
+            name: "macOS 12, Xcode 13.4.1, Swift 5.6.1 Test"
+          - xcode: "Xcode_13.3.1.app"
+            runsOn: macOS-12
+            name: "macOS 12, Xcode 13.3.1, Swift 5.6 Test"
     steps:
-    - uses: actions/checkout@v2
-
-    - run: swift test
-
+          - uses: actions/checkout@v3
+          - name: ${{ matrix.name }}
+            run: xcodebuild -scheme TMDBSwift -destination "platform=macOS" clean test
+  iOS:
+    name: "Test iOS"
+    runs-on: macOS-12
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode_13.4.1.app/Contents/Developer"
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - destination: "OS=15.5,name=iPhone 13 Pro"
+            name: "iOS 15.5 Test"
+    steps:
+      - uses: actions/checkout@v3
+      - name: ${{ matrix.name }}
+        run: xcodebuild -scheme TMDBSwift -destination "${{ matrix.destination }}" clean test
+  tvOS:
+    name: Test tvOS
+    runs-on: macOS-12
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode_13.4.1.app/Contents/Developer"
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - destination: "OS=15.4,name=Apple TV"
+            name: "tvOS 15.4 Test"
+    steps:
+      - uses: actions/checkout@v3
+      - name: ${{ matrix.name }}
+        run: xcodebuild -scheme TMDBSwift -destination "${{ matrix.destination }}" clean test
+  watchOS:
+    name: Test watchOS
+    runs-on: macOS-12
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode_13.4.1.app/Contents/Developer"
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - destination: "OS=8.5,name=Apple Watch Series 7 - 45mm"
+            name: "watchOS 8.5 Test"
+    steps:
+      - uses: actions/checkout@v3
+      - name: ${{ matrix.name}}
+        run: xcodebuild -scheme TMDBSwift -destination "${{ matrix.destination }}" clean test
+  SPM:
+    name: Test with SPM
+    runs-on: ${{ matrix.runsOn }}
+    env:
+      DEVELOPER_DIR: "/Applications/${{ matrix.xcode }}/Contents/Developer"
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - xcode: "Xcode_13.4.1.app"
+            runsOn: macOS-12
+            name: "macOS 12, SPM 5.6.1 Test"
+            action: swift test -c debug
+          - xcode: "Xcode_13.3.1.app"
+            runsOn: macOS-12
+            name: "macOS 12, SPM 5.6 Test"
+            action: swift test -c debug
+    steps:
+      - uses: actions/checkout@v3
+      - name: Test SPM
+        run: ${{ matrix.action }}


### PR DESCRIPTION
- Using a set of matrices to ensure total coverage across all of the frameworks and support versions
- As new versions release they will be added to the pre-defined matrices

This does make the CI take a few minutes longer due to concurrency queueing, however the coverage peace of mind should be worth the handful of extra minutes. 